### PR TITLE
Separate Linux build and install steps

### DIFF
--- a/Builds/LinuxMakefile/buildCabbage
+++ b/Builds/LinuxMakefile/buildCabbage
@@ -12,69 +12,71 @@ echo "located in /user/local/lib "
 echo "It is also assumes that the VST SDK is located in ~/SDKs/"
 echo ""
 
-mkdir usr/share/doc/cabbage
+if [ $1 == "debug" ]; then
+  echo "Hello debug"
+  ../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbageIDE.jucer
+  mv Makefile MakeCabbageIDE
+  make -f MakeCabbageIDE clean
+  make -f MakeCabbageIDE -j6 
+  cp ./build/Cabbage /usr/bin/Cabbage
 
+  ../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbagePlugin.jucer
+  mv Makefile MakePluginEffect
+  make -f MakePluginEffect clean 
+  make -f MakePluginEffect -j6
 
-if [ $1 == "debug" ]
-then
-echo "Hello debug"
-../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbageIDE.jucer
-mv Makefile MakeCabbageIDE
-make -f MakeCabbageIDE clean
-make -f MakeCabbageIDE -j6 
-cp ./build/Cabbage /usr/bin/Cabbage
-
-../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbagePlugin.jucer
-mv Makefile MakePluginEffect
-make -f MakePluginEffect clean 
-make -f MakePluginEffect -j6
-
-../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbagePluginSynth.jucer
-mv Makefile MakePluginSynth
-make -f MakePluginSynth clean
-make -f MakePluginSynth -j6 
+  ../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbagePluginSynth.jucer
+  mv Makefile MakePluginSynth
+  make -f MakePluginSynth clean
+  make -f MakePluginSynth -j6 
 else
-#release mode  default
-../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbageIDE.jucer
-mv Makefile MakeCabbageIDE
-make -f MakeCabbageIDE clean CONFIG=Release
-make -f MakeCabbageIDE -j6 CONFIG=Release
-cp ./build/Cabbage /usr/bin/Cabbage
+  #release mode  default
 
-../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbagePlugin.jucer
-mv Makefile MakePluginEffect
+  mkdir -p ./install/bin ./install/images ./install/desktop
 
-make -f MakePluginEffect clean CONFIG=Release
-make -f MakePluginEffect -j6 CONFIG=Release
-cp ./build/CabbagePlugin.so /usr/bin/CabbagePluginEffect.so
+  ../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbageIDE.jucer
+  mv Makefile MakeCabbageIDE
+  echo "$(tput bold)Building CabbageIDE…$(tput sgr0)"
 
-../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbagePluginSynth.jucer
-mv Makefile MakePluginSynth
+  make -f MakeCabbageIDE clean CONFIG=Release
+  make -f MakeCabbageIDE -j6 CONFIG=Release
+  cp ./build/Cabbage ./install/bin/Cabbage
 
-make -f MakePluginSynth clean CONFIG=Release
-make -f MakePluginSynth -j6 CONFIG=Release
-cp ./build/CabbagePlugin.so /usr/bin/CabbagePluginSynth.so
+  ../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbagePlugin.jucer
+  mv Makefile MakePluginEffect
+  echo "$(tput bold)Building PluginEffect…$(tput sgr0)"
 
-../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbageLite.jucer
-mv Makefile MakeCabbageLite
+  make -f MakePluginEffect clean CONFIG=Release
+  make -f MakePluginEffect -j6 CONFIG=Release
+  cp ./build/CabbagePlugin.so ./install/bin/CabbagePluginEffect.so
 
-make -f MakeCabbageLite clean CONFIG=Release
-make -f MakeCabbageLite -j6 CONFIG=Release
-cp ./build/CabbageLite /usr/bin/CabbageLite
+  ../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbagePluginSynth.jucer
+  mv Makefile MakePluginSynth
+  echo "$(tput bold)Building PluginSynth…$(tput sgr0)"
 
+  make -f MakePluginSynth clean CONFIG=Release
+  make -f MakePluginSynth -j6 CONFIG=Release
+  cp ./build/CabbagePlugin.so ./install/bin/CabbagePluginSynth.so
+
+  ../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbageLite.jucer
+  mv Makefile MakeCabbageLite
+  echo "$(tput bold)Building CabbageLite…$(tput sgr0)"
+
+  make -f MakeCabbageLite clean CONFIG=Release
+  make -f MakeCabbageLite -j6 CONFIG=Release
+  cp ./build/CabbageLite ./install/bin/CabbageLite
 fi  
 
-cp ./../opcodes.txt /usr/bin/opcodes.txt
-cp ./../../Images/cabbage.png /usr/share/icons/hicolor/512x512/apps/cabbage.png
-cp ./../../Images/cabbage.png /usr/share/icons/hicolor/512x512/apps/cabbagelite.png
-mkdir /usr/share/doc/cabbage/
-cp -rf ../../Examples/ /usr/share/doc/cabbage/Examples
+echo "$(tput bold)Copying over docs and icons…$(tput sgr0)"
+cp ./../opcodes.txt ./install/bin/opcodes.txt
+cp ./../../Images/cabbage.png ./install/images/cabbage.png
+cp ./../../Images/cabbage.png ./install/images/cabbagelite.png
+cp -rf ../../Examples ./install/
 
 g++ ../../Source/testCsoundFile.cpp -o testCsoundFile -I"/usr/local/include/csound" -lcsound64
-cp testCsoundFile /usr/bin/testCsoundFile
+cp testCsoundFile ./install/bin/testCsoundFile
 #cp -rf ../../Docs/_book CabbageBuild/Docs
 
-sed "s@CURRENTDIR@$(pwd)@" Cabbage.desktop > cabbage.desktop
-sed "s@CURRENTDIR@$(pwd)@" Cabbage.desktop > cabbagLite.desktop
+sed "s@CURRENTDIR@$(pwd)@" Cabbage.desktop > ./install/desktop/cabbage.desktop
+sed "s@CURRENTDIR@$(pwd)@" Cabbage.desktop > ./install/desktop/cabbageLite.desktop
 # sed "s@CURRENTDIR@$(pwd)@" dummy.desktop > CabbageBuild/cabbagelite.desktop
-cp cabbage.desktop ~/.local/share/applications/

--- a/Builds/LinuxMakefile/installCabbage
+++ b/Builds/LinuxMakefile/installCabbage
@@ -1,0 +1,68 @@
+#!/bin/bash  
+
+bin_path_default='/usr/bin'
+icon_path_default='/usr/share/icons/hicolor/512x512/apps'
+doc_path_default='/usr/share/doc/cabbage'
+desktop_path_default='/usr/share/applications'
+
+bin_path=$bin_path_default
+icon_path=$icon_path_default
+doc_path=$doc_path_default
+desktop_path=$desktop_path_default
+
+build_path="./install"
+
+while getopts ":hb:i:d:t:" opt; do
+  case $opt in
+    h)
+      echo "Usage:"
+      echo " `basename "$0"` [options]"
+      echo
+      echo "Options:"
+      echo " -b <bin_path>      where to install binary files"
+      echo "                      default: $bin_path_default"
+      echo " -i <icon_path>     where to install desktop icons"
+      echo "                      default: $icon_path_default"
+      echo " -d <doc_path>      where to install documentation"
+      echo "                      default: $doc_path_default"
+      echo " -t <desktop_path>  where to install desktop entries"
+      echo "                      default: $desktop_path_default"
+      exit 0
+      ;;
+    b)
+      bin_path="$OPTARG"
+      ;;
+    i)
+      icon_path="$OPTARG"
+      ;;
+    d)
+      doc_path="$OPTARG"
+      ;;
+    t)
+      desktop_path="$OPTARG"
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG"
+      exit 1
+      ;;
+  esac
+done
+
+install -d "$icon_path"
+for file in "$build_path"/images/*; do
+  install -m644 "$file" "$icon_path"
+done
+
+install -d "$bin_path"
+for file in "$build_path"/bin/*; do
+  install -m755 "$file" "$bin_path"
+done
+
+install -d "$desktop_path"
+for file in "$build_path"/desktop/*; do
+  install -m644 "$file" "$desktop_path"
+done
+
+install -d "$doc_path"
+cp -r "${build_path}/Examples" "$doc_path"
+chmod -R 755 "$doc_path"


### PR DESCRIPTION
Modify buildCabbage to move post-compilation files into a local
directory "install" rather than into system directories. Add a script
installCabbage to handle moving the files into system directories
instead, with options to specify directories other than the default.
Also add status messages to buildCabbage to make it easier to track
what's happening during the build process.