### PR TITLE
Fix pluginid("NAME") duplicates throughout .csd Examples directory.

### DIFF
--- a/Examples/Effects/Dynamics/Compressor.csd
+++ b/Examples/Effects/Dynamics/Compressor.csd
@@ -23,7 +23,7 @@
 
 <Cabbage>
 #define SLIDER_APPEARANCE trackercolour("DarkSlateGrey"), textcolour("black") 
-form caption("Compressor") size(440,130), pluginid("comp")
+form caption("Compressor") size(440,130), pluginid("Comp")
 image            bounds(  0,  0,440,130), outlinethickness(6), outlinecolour("white"), colour("grey")
 rslider bounds( 10, 10, 70, 70), channel("thresh"), text("Threshold"), range(0,120,0), $SLIDER_APPEARANCE
 rslider bounds( 80, 10, 70, 70), channel("att"), text("Attack"),  range(0,1,0.01,0.5), $SLIDER_APPEARANCE

--- a/Examples/Effects/Dynamics/Exciter.csd
+++ b/Examples/Effects/Dynamics/Exciter.csd
@@ -8,7 +8,7 @@
 ; The effect of these parameters is subtle and the user might find it useful to at first set 'Dry/Wet Mix' to maximum (100% wet) in order to hear the effect more clearly.
              
 <Cabbage>
-form caption("Exciter") size(445, 100), pluginid("scho")
+form caption("Exciter") size(445, 100), pluginid("Ectr")
 image           bounds(0, 0, 445, 100), colour("LightSlateGrey"), shape("rounded"), outlinecolour("white"), outlinethickness(6)
 rslider  bounds( 10, 13, 75, 75), text("Frequency"), channel("freq"), range(20,20000,3000,0.5),  textcolour("white"), colour(37,59,59), trackercolour("Silver")
 rslider  bounds( 80, 13, 75, 75), text("Ceiling"), channel("ceil"), range(20,20000,20000,0.5), textcolour("white"), colour(37,59,59), trackercolour("Silver")

--- a/Examples/Effects/Filters/BandFilter.csd
+++ b/Examples/Effects/Filters/BandFilter.csd
@@ -2,7 +2,7 @@
 ; Written by Iain McCurdy, 2012.
 
 <Cabbage>
-form caption("Band Filter"), colour(10,10,10), size(470, 360), pluginid("band")  
+form caption("Band Filter"), colour(10,10,10), size(470, 360), pluginid("BdFl")
 xypad bounds(5, 5, 350, 350), channel("cf", "bw"), rangex(0, 1, 0.5), rangey(0, 1, 0.3), text("x:cutoff | y:bandwidth"), colour(200,200,200)
 checkbox bounds(370, 10, 20, 20), channel("balance"), FontColour("white"),  value(0)
 label    bounds(395, 15, 55, 15), text("Balance"), FontColour("white")

--- a/Examples/Effects/Modulation/StereoChorus.csd
+++ b/Examples/Effects/Modulation/StereoChorus.csd
@@ -7,7 +7,7 @@
 ; Dereg. (deregulate) adds a random modulation to both LFO rate and depth in both LFO modes
 
 <Cabbage>
-form caption("Stereo Chorus") size(595, 100), pluginid("scho")
+form caption("Stereo Chorus") size(595, 100), pluginid("StCh")
 image                 bounds(0, 0, 595, 100), colour("DarkSlateGrey"), shape("rounded"), outlinecolour("white"), outlinethickness(6)
 label    bounds( 15, 22, 75, 12), text("LFO Type:"), fontcolour("white")
 combobox bounds( 15, 35, 75, 20), text("Sine","RSpline"), channel("type"), textcolour("white"), colour( 7,29,29), fontcolour("white")

--- a/Examples/Effects/Time/TempoDelay.csd
+++ b/Examples/Effects/Time/TempoDelay.csd
@@ -7,7 +7,7 @@
 ; If 'external' is selected as clock source tempo is taken from the host's BPM. 
 
 <Cabbage>
-form caption("Tempo Delay") size(565, 90), pluginid("TDel")
+form caption("Tempo Delay") size(565, 90), pluginid("TpDl")
 image pos(0, 0), size(565, 90), colour("LightBlue"), shape("rounded"), outlinecolour("white"), outlinethickness(4) 
 rslider bounds(10, 11, 70, 70), text("Tempo"), 		textcolour("black"), 		channel("tempo"), 	range(40, 500, 90, 1, 1),   colour(100,100,255),trackercolour(100,100,150)
 rslider bounds(75, 11, 70, 70), text("Rhy.Mult."),	textcolour("black"), 		channel("RhyMlt"), 	range(1, 16, 4, 1, 1),      colour(100,100,255),trackercolour(100,100,150)

--- a/Examples/Effects/Time/TriggerDelay.csd
+++ b/Examples/Effects/Time/TriggerDelay.csd
@@ -15,7 +15,7 @@
 ; 'Width' allows the user to vary the delay from a simple monophonic delay to a ping-pong style delay
 
 <Cabbage>
-form caption("Trigger Delay") size(540,240), pluginid("TDel")
+form caption("Trigger Delay") size(540,240), pluginid("TrDl")
 image                  bounds(0, 0,540,240), colour(150,150,205), shape("rounded"), outlinecolour("white"), outlinethickness(4) 
 
 rslider  bounds(  5, 11, 70, 70),  text("Threshold"), textcolour("black"),  channel("threshold"), range(0, 1.00, 0.1, 0.5),      colour( 40, 40, 95),trackercolour("white")

--- a/Examples/GEN/GEN20.csd
+++ b/Examples/GEN/GEN20.csd
@@ -2,7 +2,7 @@
 ; Written by Iain McCurdy, 2014
 
 <Cabbage>
-form caption("GEN20"), size(410, 230), pluginid("gn10"), colour("20,70,170,150")
+form caption("GEN20"), size(410, 230), pluginid("gn20"), colour("20,70,170,150")
 
 gentable bounds(  5,  5, 400, 120), tablenumber(1), identchannel("table1"), zoom(-1), amprange(0,1,1), tablecolour("LightSlateGrey"), zoom(-1), tablebackgroundcolour("white"), fill(0), outlinethickness(2) tablegridcolour(220,220,220)
 

--- a/Examples/Instruments/Drum Machines/TR-808.csd
+++ b/Examples/Instruments/Drum Machines/TR-808.csd
@@ -6,7 +6,7 @@
 ; Choosing 'Host Control' allows the VST plugin host to decide 'Tempo' and 'Run/Stop' status
 
 <Cabbage>
-form caption("TR-808") size(800, 400), colour("SlateGrey"), pluginid("T808"), guirefresh(32)
+form caption("TR-808") size(800, 400), colour("SlateGrey"), pluginid("808B"), guirefresh(32)
 
 label 		bounds(  5,385,120, 12), text("Iain McCurdy |2012|"), fontcolour("black")
 

--- a/Examples/Instruments/Drum Machines/TR-808.csd
+++ b/Examples/Instruments/Drum Machines/TR-808.csd
@@ -6,7 +6,7 @@
 ; Choosing 'Host Control' allows the VST plugin host to decide 'Tempo' and 'Run/Stop' status
 
 <Cabbage>
-form caption("TR-808") size(800, 400), colour("SlateGrey"), pluginid("808B"), guirefresh(32)
+form caption("TR-808") size(800, 400), colour("SlateGrey"), pluginid("T808"), guirefresh(32)
 
 label 		bounds(  5,385,120, 12), text("Iain McCurdy |2012|"), fontcolour("black")
 

--- a/Examples/Instruments/Drum Machines/TR-808_BACKUP_10598.csd
+++ b/Examples/Instruments/Drum Machines/TR-808_BACKUP_10598.csd
@@ -6,7 +6,7 @@
 ; Choosing 'Host Control' allows the VST plugin host to decide 'Tempo' and 'Run/Stop' status
 
 <Cabbage>
-form caption("TR-808") size(800, 400), colour("SlateGrey"), pluginid("T808"), guirefresh(32)
+form caption("TR-808") size(800, 400), colour("SlateGrey"), pluginid("808B"), guirefresh(32)
 
 label 		bounds(  5,385,120, 12), text("Iain McCurdy |2012|"), fontcolour("black")
 

--- a/Examples/MIDI/MIDI_Out.csd
+++ b/Examples/MIDI/MIDI_Out.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("MIDI Out"), size(400,80), pluginid("Mout")
+form caption("MIDI Out"), size(400,80), pluginid("MOt1")
 keyboard bounds(0,0,400,80)
 </Cabbage>
 

--- a/Examples/MIDI/MIDI_Out2.csd
+++ b/Examples/MIDI/MIDI_Out2.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("MIDI Out"), size(400,80), pluginid("Mout")
+form caption("MIDI Out"), size(400,80), pluginid("Mot2")
 keyboard bounds(0,0,400,80)
 </Cabbage>
 

--- a/Examples/Miscellaneous/CabbageGUIArrays.csd
+++ b/Examples/Miscellaneous/CabbageGUIArrays.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form size(500, 535), caption(""), pluginid("plu1")
+form size(500, 535), caption(""), pluginid("CGAr")
 checkbox bounds(-100, -100, 50, 50), text("Push"), widgetarray("test", 100), value(0)
 </Cabbage>
 <CsoundSynthesizer>

--- a/Examples/Miscellaneous/CabbageOSCRec.csd
+++ b/Examples/Miscellaneous/CabbageOSCRec.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("OSCRec"), size(470, 260), pluginid("band"), guirefresh(10)
+form caption("OSCRec"), size(470, 260), pluginid("OSCR"), guirefresh(10)
 rslider bounds(10, 10, 80, 80), channel("test1"), range(0, 1, 0, 1, .01)
 rslider bounds(100, 10, 80, 80), channel("test2"), range(0, 1, 0, 1, .01)
 </Cabbage>

--- a/Examples/Miscellaneous/CabbageOSCSend.csd
+++ b/Examples/Miscellaneous/CabbageOSCSend.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("OSCSend"), size(470, 260), pluginid("band"), guirefresh(10)
+form caption("OSCSend"), size(470, 260), pluginid("OSCS"), guirefresh(10)
 rslider bounds(10, 10, 80, 80), channel("rslider1"), colour("red"), range(0, 1, 0, 1, .01)
 rslider bounds(100, 10, 80, 80), channel("rslider2"), colour("red"), range(0, 1, 0, 1, .01)
 

--- a/Examples/Miscellaneous/CsoundFiltersWobble.csd
+++ b/Examples/Miscellaneous/CsoundFiltersWobble.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Csound Filters") size(400, 220), colour(20, 20, 20), pluginid("def1")
+form caption("Csound Filters") size(400, 220), colour(20, 20, 20), pluginid("CsFW")
 keyboard bounds(12, 84, 381, 95), value(20)
 combobox bounds(12, 8, 381, 30), align("centre"), channel("filerTypeCombo"), items("MOOG_LADDER", "MOOG_VCF   ", "LPF18      ", "BQREZ      ", "CLFILT     ", "BUTTERLP   ", "LOWRES     ", "REZZY      ", "SVFILTER   ", "VLOWRES    ", "STATEVAR   ", "MVCLPF1    ", "MVCLPF2    ", "MVCLPF3    ")
 hslider bounds(12, 40, 361, 39), channel("coeffSlider"), range(0.01, 2, .5), text("LFO Rate")

--- a/Examples/Miscellaneous/CsoundOutput.csd
+++ b/Examples/Miscellaneous/CsoundOutput.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Csound output") size(480,400), pluginid("SMo1"), guirefresh(10)
+form caption("Csound output") size(480,400), pluginid("CSOp"), guirefresh(10)
 csoundoutput bounds(8, 4, 467, 353), colour("black"), fontcolour("lime")
 </Cabbage>
 <CsoundSynthesizer>

--- a/Examples/Miscellaneous/DynamicEnveloper.csd
+++ b/Examples/Miscellaneous/DynamicEnveloper.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("ADSR Enveloper") size(400, 280), colour(40, 40, 40), pluginid("def1")
+form caption("ADSR Enveloper") size(400, 280), colour(40, 40, 40), pluginid("DyEn")
 keyboard bounds(8, 170, 381, 95)
 
 gentable bounds(5, 10, 380, 140), tablenumber(1), amprange(0, 1, 1, 0.0100), active(1), tablecolour:0(0, 200, 0, 100), identchannel("genTable1")

--- a/Examples/Miscellaneous/EventSequencer.csd
+++ b/Examples/Miscellaneous/EventSequencer.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Event Sequencer") size(600, 400), pluginid("def1")
+form caption("Event Sequencer") size(600, 400), pluginid("EvSq")
 eventsequencer bounds(10, 10, 500, 320), channels("step"), active(0) identchannel("trackerIdent"), orientation("horizontal"), colprefix(0:1:2:3, "i\"Sine\" 0 1 "), showstepnumbers(4), matrixsize(16, 4) textcolour(200, 200, 200), highlightcolour(30, 30, 30) outlinecolour(80,80,80), bpm(180), fontcolour("white") backgroundcolour(20, 20, 20)
 rslider bounds(514, 10, 70, 70) channel("bpm") range(10, 400, 180, 1, 0.001) text("BPM") 
 button bounds(514, 82, 70, 27) channel("startPlayback") text("Start", "Stop")  

--- a/Examples/Miscellaneous/FileRecord.csd
+++ b/Examples/Miscellaneous/FileRecord.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Rercord to file") size(400, 200), colour(58, 110, 182), pluginid("def1")
+form caption("Rercord to file") size(400, 200), colour(58, 110, 182), pluginid("FlRe")
 button bounds(4, 6, 163, 40), channel("record"), text("Record to disk", "Stop recording to disk"), 
 </Cabbage>
 <CsoundSynthesizer>

--- a/Examples/Miscellaneous/FirstSynth.csd
+++ b/Examples/Miscellaneous/FirstSynth.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form size(380, 160), caption("Simple synth"), pluginid("plu1")
+form size(380, 160), caption("Simple synth"), pluginid("1Syn")
 keyboard bounds(12, 6, 360, 100)
 </Cabbage>
 <CsoundSynthesizer>

--- a/Examples/Miscellaneous/FunctionTablesAsGrid.csd
+++ b/Examples/Miscellaneous/FunctionTablesAsGrid.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Grid Sequencer") size(580, 370), colour("black"),pluginid("add1") 
+form caption("Grid Sequencer") size(580, 370), colour("black"),pluginid("FTaG")
 
 gentable bounds(10, 10, 560, 245), tablenumber(11:12:13:14:15:16:17:18), active(1), tablebackgroundcolour("black"), tablecolour("lime") zoom(-1), amprange(0, 1, -1, 1)
 rslider bounds(14, 264, 60, 60) channel("bpmSlider") range(20, 500, 200, 1, 0.001) text("BPM")

--- a/Examples/Miscellaneous/GridSequencerImport.csd
+++ b/Examples/Miscellaneous/GridSequencerImport.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Grid Sequencer") size(544, 480), colour(120, 120, 120),pluginid("add1"), guirefresh(128), import("gridSequencer.plant")
+form caption("Grid Sequencer") size(544, 480), colour(120, 120, 120),pluginid("GdSI"), guirefresh(128), import("gridSequencer.plant")
 gridSequencer bounds(7, 7, 535, 337), channel("grid"), namespace("rw")
 button bounds(10, 430, 148, 40) channel("random") value(1) text("Randomise", "Randomise") 
 button bounds(10, 390, 148, 40) channel("clear") value(1) text("Clear", "Clear") 

--- a/Examples/Miscellaneous/HostInfo.csd
+++ b/Examples/Miscellaneous/HostInfo.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form size(440, 320), caption("Host Info"), pluginid("plu1"), guirefresh(10), colour("white")
+form size(440, 320), caption("Host Info"), pluginid("HtIn"), guirefresh(10), colour("white")
 label bounds(5, 10, 430, 30), colour(100, 0, 0), text("BPM:"), align("left"), identchannel("BPMLabel")
 label bounds(5, 48, 430, 30), colour(90, 0, 0), text("Playing:"), align("left"), identchannel("IsPlayingLabel")
 label bounds(5, 86, 430, 30), colour(80, 0, 0), text("Recording:"), align("left"), identchannel("IsRecordingLabel")

--- a/Examples/Miscellaneous/InfoButton.csd
+++ b/Examples/Miscellaneous/InfoButton.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Csound output") size(480,400), pluginid("SMo1"), guirefresh(10)
+form caption("Csound output") size(480,400), pluginid("InBt"), guirefresh(10)
 infobutton bounds(10, 10, 100, 50), file("example1.html"), text("Help"), colour("red"), fontcolour("blue")
 </Cabbage>
 <CsoundSynthesizer>

--- a/Examples/Miscellaneous/KnobManSliders.csd
+++ b/Examples/Miscellaneous/KnobManSliders.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Knobman Filmstrip Example") size(450, 180), colour(93, 93, 93), pluginid("def1")
+form caption("Knobman Filmstrip Example") size(450, 180), colour(93, 93, 93), pluginid("KMSl")
 
 image bounds(10, 23, 32, 107), file("roland SH 101 knob.png"), crop(0, 0, 32, 107), identchannel("sliderIdent1")
 vslider bounds(10, 22, 27, 106) channel("vslider1") range(0, 1, 0, 1, 0.001) alpha(0)

--- a/Examples/Miscellaneous/LiveSVGs.csd
+++ b/Examples/Miscellaneous/LiveSVGs.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Live SVGs") size(330, 180), colour("black"), pluginid("SMo1"), svgpath(".")
+form caption("Live SVGs") size(330, 180), colour("black"), pluginid("LSVG"), svgpath(".")
 
 rslider bounds(12, 14, 130, 122), channel("rslider"), range(0, 1, 0), identchannel("svgIdent")
 </Cabbage>  

--- a/Examples/Miscellaneous/MouseSense.csd
+++ b/Examples/Miscellaneous/MouseSense.csd
@@ -2,7 +2,7 @@
 ; Written by Iain McCurdy, 2014
 
 <Cabbage>
-form caption("Mouse Sense") size(785, 400), pluginid("SMo1"), guirefresh(16)
+form caption("Mouse Sense") size(785, 400), pluginid("MsSe"), guirefresh(16)
 
 nslider bounds( 55, 25, 90, 35), text("MOUSE X"),             fontcolour("white"), textbox(1),                channel("X"),           range(0, 800, 0,1,1)
 nslider bounds(160, 25, 90, 35), text("MOUSE Y"),             fontcolour("white"), textbox(1),                channel("Y"),           range(0, 400, 0,1,1)

--- a/Examples/Miscellaneous/PopupPlant.csd
+++ b/Examples/Miscellaneous/PopupPlant.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Popup Plants") size(285, 100), pluginid("SMo1"), guirefresh(10)
+form caption("Popup Plants") size(285, 100), pluginid("PupP"), guirefresh(10)
 groupbox bounds(10, 76, 220, 130), text("Popup Plant"), plant("pop1"), popup(1), colour(20, 20, 20), identchannel("pops") {
 rslider bounds(6, 24, 50, 50), channel("rslider1"), range(0, 100, 10)
 rslider bounds(58, 24, 50, 50), channel("rslider2"), range(0, 100, 20)

--- a/Examples/Miscellaneous/Presets.csd
+++ b/Examples/Miscellaneous/Presets.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Presets") size(370, 280), colour(58, 110, 182), pluginid("def1")
+form caption("Presets") size(370, 280), colour(58, 110, 182), pluginid("MPre")
 keyboard bounds(10, 90, 345, 95)
 rslider bounds(12, 8, 85, 79), channel("att"), range(0, 1, 0.01), text("Att.")
 rslider bounds(98, 8, 85, 79), channel("dec"), range(0, 1, 0.4), text("Dec.")

--- a/Examples/Miscellaneous/RadioButtons.csd
+++ b/Examples/Miscellaneous/RadioButtons.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Radio Buttons") size(300, 200), pluginid("SMo1"), guirefresh(10)
+form caption("Radio Buttons") size(300, 200), pluginid("RdBt"), guirefresh(10)
 
 button bounds(8, 122, 60, 25), channel("but10"), radiogroup(101), colour:1("blue"), value(1), text("Zero", "One")
 button bounds(82, 122, 60, 25), channel("but11"), radiogroup(101), colour:1("blue"), text("Zero", "One")

--- a/Examples/Miscellaneous/RandomCheckbox.csd
+++ b/Examples/Miscellaneous/RandomCheckbox.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form size(600, 200), caption("Rnadom Checkbox"), pluginid("plu1")
+form size(600, 200), caption("Rnadom Checkbox"), pluginid("RnCB")
 checkbox bounds(0, 0, 50, 50), identchannel("checkboxIdent")
 </Cabbage>
 <CsoundSynthesizer>

--- a/Examples/Miscellaneous/SVGExample.csd
+++ b/Examples/Miscellaneous/SVGExample.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("SVG Example") size(530, 480), colour("black"), pluginid("SMo1")
+form caption("SVG Example") size(530, 480), colour("black"), pluginid("SVGE")
  groupbox bounds(122, 4, 376, 135), text("")
  groupbox bounds(120, 152, 379, 277), text(""), imgfile("custom_groupbox.svg"), identchannel("groupbox")
 rslider bounds(18, 90, 87, 85) channel("Waveshape1") imgfile("Slider", "rslider.svg") imgfile("background", "rslider_background.svg"), range(0, 5, 0, 1, 1) trackercolour(255, 165, 0, 255) trackerthickness(.5),

--- a/Examples/Miscellaneous/SampleLoadAndPlayback.csd
+++ b/Examples/Miscellaneous/SampleLoadAndPlayback.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Sample load and playback") size(635,430), pluginid("comp"), colour("whitesmoke")
+form caption("Sample load and playback") size(635,430), pluginid("SLaP"), colour("whitesmoke")
 soundfiler bounds(10, 10, 150, 80) identchannel("soundfiler1") tablenumber(-1) 
 soundfiler bounds(165, 10, 150, 80) identchannel("soundfiler2") tablenumber(-1) 
 soundfiler bounds(320, 10, 150, 80) identchannel("soundfiler3") tablenumber(-1) 

--- a/Examples/Miscellaneous/SimpleSynthGainSlider.csd
+++ b/Examples/Miscellaneous/SimpleSynthGainSlider.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form size(400, 190), caption("Simple Synth"), pluginid("plu1")
+form size(400, 190), caption("Simple Synth"), pluginid("SSGS")
 hslider bounds(5, 110, 380, 50), channel("gain"), range(0, 1, .5), colour("white")
 keyboard bounds(10, 5, 380, 100)
 </Cabbage>

--- a/Examples/Miscellaneous/Soundfiler.csd
+++ b/Examples/Miscellaneous/Soundfiler.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Soundfiler") size(430, 240), colour(58, 110, 182), pluginid("def1")
+form caption("Soundfiler") size(430, 240), colour(58, 110, 182), pluginid("Sflr")
  
 combobox bounds(324, 188, 100, 25), channel("presetsCombo"), populate("*.snaps")
 filebutton bounds(262, 188, 60, 25) value(0) text("Save", "Save") mode("snapshot") 

--- a/Examples/Miscellaneous/TextEditor.csd
+++ b/Examples/Miscellaneous/TextEditor.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form size(410, 330), caption("Text Editor"), pluginid("plu1")
+form size(410, 330), caption("Text Editor"), pluginid("TxEd")
 texteditor bounds(12, 34, 387, 20), channel("texteditor"), text("Type here...."), color(20, 20, 20), fontcolour(0, 0, 0, 255), 
 csoundoutput bounds(12, 60, 387, 149)
 label bounds(12, 8, 387, 20), text("Enter some text and hit enter"), align("centre"),  colour(60, 0, 0), fontcolour(255, 255, 255, 255)

--- a/Examples/Miscellaneous/TogglingPlants.csd
+++ b/Examples/Miscellaneous/TogglingPlants.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form size(400, 200), caption("Toggling Plants"), pluginid("plu1"), guirefresh(10)
+form size(400, 200), caption("Toggling Plants"), pluginid("TgPl"), guirefresh(10)
 button bounds(12, 12, 60, 25), channel("but1"), text("Toggle", "Toggle")
 
 groupbox bounds(80, 10, 200, 160), text("White Sliders"), visible(0), identchannel("sliders1"), plant("GUIabst_1"){

--- a/Examples/Miscellaneous/WidgetArrays.csd
+++ b/Examples/Miscellaneous/WidgetArrays.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form size(260, 290), caption(""), pluginid("plu1")
+form size(260, 290), caption(""), pluginid("WdAr")
 checkbox bounds(-100, -100, 25, 25), text("Push"), widgetarray("check", 100), value(0)
 button bounds(10, 260, 100, 30), text("Toggle"), channel("toggle")
 hslider bounds(157, 253, 103, 37) range(0, 10, 1, 1, 0.001), channel("tempo")

--- a/Examples/Miscellaneous/adsr.csd
+++ b/Examples/Miscellaneous/adsr.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Custom ADSR plant") size(320, 300), colour(18, 60, 82), import("adsr.plant"), pluginid("def1")
+form caption("Custom ADSR plant") size(320, 300), colour(18, 60, 82), import("adsr.plant"), pluginid("ADSR")
 adsr bounds(10, 10, 300, 120), channel("adsr"), namespace("cab")
 keyboard bounds(8, 158, 300, 95)
 </Cabbage>

--- a/Examples/Miscellaneous/comboboxSamplePlay.csd
+++ b/Examples/Miscellaneous/comboboxSamplePlay.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Combobox Sample Player") size(400, 100), colour(58, 110, 182), pluginid("def1")
+form caption("Combobox Sample Player") size(400, 100), colour(58, 110, 182), pluginid("CBSP")
 combobox bounds(6, 8, 80, 20) channel("combo1") channeltype("string") populate("*.wav", "/home/rory/Downloads/AKWF_bw_perfectwaves/")
 button bounds(90, 8, 80, 40) channel("button1") text("Play", "Stop") 
 </Cabbage>

--- a/Examples/Widgets/button.csd
+++ b/Examples/Widgets/button.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Button Example") size(400, 300), colour(220, 220, 220), pluginid("def1")
+form caption("Button Example") size(400, 300), colour(220, 220, 220), pluginid("Btn1")
 label bounds(8, 6, 368, 20), text("Basic Usage"), fontcolour("black")
 groupbox bounds(8, 110, 380, 177), text("Randomly Updated Identifiers")
 button bounds(116, 38, 150, 50), channel("button1"), text("Enable Tone", "Disable Tone"),

--- a/Examples/Widgets/button_file.csd
+++ b/Examples/Widgets/button_file.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("File Button Example") size(400, 300), colour(220, 220, 220), pluginid("def1")
+form caption("File Button Example") size(400, 300), colour(220, 220, 220), pluginid("BtnF")
 label bounds(8, 6, 368, 20), text("Basic Usage"), fontcolour("black")
 groupbox bounds(8, 110, 380, 177), text("Randomly Updated Identifiers")
 filebutton bounds(108, 30, 150, 50), channel("filebutton1"), text("Browsse", "Browsse") value(0) file("/Users/walshr/sourcecode/cabbage/Examples/Widgets/Sliders.csd")

--- a/Examples/Widgets/button_info.csd
+++ b/Examples/Widgets/button_info.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form size(400, 500), caption("Infobutton Example"), pluginid("plu1"), colour(39, 40, 34)
+form size(400, 500), caption("Infobutton Example"), pluginid("BtIn"), colour(39, 40, 34)
 button bounds(20, 16, 100, 30), channel("button"),  text("Push me"), fontcolour("white")
 infobutton bounds(120, 16, 100, 30), channel("button"),  file("button.csd"), text("Info")
 filebutton bounds(220, 16, 100, 30), channel("button"),  populate("*.wav", ""), text("Browse")

--- a/Examples/Widgets/checkbox.csd
+++ b/Examples/Widgets/checkbox.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Checkbox Example") size(400, 300), colour(220, 220, 220), pluginid("def1")
+form caption("Checkbox Example") size(400, 300), colour(220, 220, 220), pluginid("CkBx")
 label bounds(8, 6, 368, 20), text("Basic Usage"), fontcolour("black")
 groupbox bounds(8, 110, 380, 177), text("Randomly Updated Identifiers")
 checkbox bounds(116, 38, 150, 50), channel("checkbutton1"), text("Enable Tone", "Disable Tone"),

--- a/Examples/Widgets/combobox.csd
+++ b/Examples/Widgets/combobox.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Combobox Example") size(400, 300), colour(220, 220, 220), pluginid("def1")
+form caption("Combobox Example") size(400, 300), colour(220, 220, 220), pluginid("CmBx")
 label bounds(8, 6, 368, 20), text("Basic Usage"), fontcolour("black")
 groupbox bounds(8, 110, 380, 177), text("Randomly Updated Identifiers")
 combobox bounds(36, 38, 150, 50), channel("combobox1"), items("100Hz", "200Hz", "300Hz")

--- a/Examples/Widgets/csound_output.csd
+++ b/Examples/Widgets/csound_output.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form size(400, 500), caption("Csound output"), pluginid("plu1"), colour(39, 40, 34)
+form size(400, 500), caption("Csound output"), pluginid("WCOp"), colour(39, 40, 34)
 csoundoutput bounds(10, 10, 380, 400)
 </Cabbage>
 <CsoundSynthesizer>

--- a/Examples/Widgets/encoder.csd
+++ b/Examples/Widgets/encoder.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Encoder Example") size(400, 300), colour(220, 220, 220), pluginid("def1")
+form caption("Encoder Example") size(400, 300), colour(220, 220, 220), pluginid("Enc1")
 label bounds(8, 6, 368, 20), text("Basic Usage"), fontcolour("black")
 encoder bounds(8, 38, 369, 50), channel("gain"), text("Gain") min(0), max(1), increment(.01) fontcolour(91, 46, 46, 255) textcolour(29, 29, 29, 255)
 groupbox bounds(8, 110, 380, 177), text("Randomly Updated Identifiers")

--- a/Examples/Widgets/event_sequencer.csd
+++ b/Examples/Widgets/event_sequencer.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("String Sequencer") size(400, 400), pluginid("def1")
+form caption("String Sequencer") size(400, 400), pluginid("EtSq")
 stringsequencer bounds(10, 10, 300, 320), channels("step", "track1", "track2", "track3", "track4"), active(0), identchannel("trackerIdent"), textcolour(200, 200, 200), highlightcolour(60, 60, 60) outlinecolour(80,80,80), bpm(180), fontcolour("white") backgroundcolour(20, 20, 20) showstepnumbers(4), numberofsteps(16)
 rslider bounds(314, 10, 70, 70) channel("bpm") range(10, 300, 180, 1, 0.001) text("BPM") 
 button bounds(314, 82, 70, 27) channel("startStop") text("Start", "Stop") 

--- a/Examples/Widgets/form.csd
+++ b/Examples/Widgets/form.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form size(400, 500), caption("Form Example"), pluginid("plu1"), colour(39, 40, 34)
+form size(400, 500), caption("Form Example"), pluginid("Form"), colour(39, 40, 34)
 </Cabbage>
 <CsoundSynthesizer>
 <CsOptions>

--- a/Examples/Widgets/gentable.csd
+++ b/Examples/Widgets/gentable.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Gentable Example") size(400, 300), colour(220, 220, 220), pluginid("def1")
+form caption("Gentable Example") size(400, 300), colour(220, 220, 220), pluginid("GenT")
 label bounds(8, 6, 368, 20), text("Basic Usage"), fontcolour("black")
 gentable bounds(8, 30, 380, 70), tablenumber(1), tablegridcolour(0, 0, 0, 255), fill(0)
 groupbox bounds(8, 110, 380, 177), text("Randomly Updated Identifiers")

--- a/Examples/Widgets/groupbox.csd
+++ b/Examples/Widgets/groupbox.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Groupbox example") size(400, 300), colour(220, 220, 220), pluginid("def1")
+form caption("Groupbox example") size(400, 300), colour(220, 220, 220), pluginid("GrBx")
 label bounds(8, 6, 368, 20), text("Basic Usage"), fontcolour("black")
 groupbox bounds(10, 34, 378, 73), text("I'm a groupbox"), colour(80, 80, 80)
 groupbox bounds(8, 118, 380, 177), text("Randomly Updated Identifiers")

--- a/Examples/Widgets/hrange.csd
+++ b/Examples/Widgets/hrange.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("HRange Example") size(400, 300), colour(220, 220, 220), pluginid("def1")
+form caption("HRange Example") size(400, 300), colour(220, 220, 220), pluginid("HRge")
 label bounds(8, 6, 368, 20), text("Basic Usage"), fontcolour("black")
 groupbox bounds(8, 110, 380, 177), text("Randomly Updated Identifiers")
 hrange bounds(120, 34, 160, 40), channel("hrangeL", "hrangeR"), colour(123, 34, 143), range(100, 1000, 200:300, 1, .01)

--- a/Examples/Widgets/image.csd
+++ b/Examples/Widgets/image.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Image Example") size(400, 300), colour(220, 220, 220), pluginid("def1")
+form caption("Image Example") size(400, 300), colour(220, 220, 220), pluginid("Imge")
 label bounds(8, 6, 368, 20), text("Basic Usage"), fontcolour("black")
 label bounds(6, 26, 380, 18) text("Image: click to send info to Csound") fontcolour(118, 118, 118, 255)
 groupbox bounds(8, 110, 380, 177), text("Randomly Updated Identifiers")

--- a/Examples/Widgets/keyboard.csd
+++ b/Examples/Widgets/keyboard.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form size(400, 300), caption("Keyboard"), pluginid("plu1")
+form size(400, 300), caption("Keyboard"), pluginid("Kbrd")
 keyboard bounds(10, 10, 385, 160), identchannel("widgetIdent")
 </Cabbage>
 <CsoundSynthesizer>

--- a/Examples/Widgets/label.csd
+++ b/Examples/Widgets/label.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Label Example") size(400, 300), colour(220, 220, 220), pluginid("def1")
+form caption("Label Example") size(400, 300), colour(220, 220, 220), pluginid("Labl")
 label bounds(8, 6, 368, 20), text("Basic Usage"), fontcolour("black")
 groupbox bounds(8, 110, 380, 177), text("Randomly Updated Identifiers")
 label bounds(50, 38, 300, 18), channel("label1"), colour(20, 20, 20), text("Label. Click to send info to Csound")

--- a/Examples/Widgets/listbox.csd
+++ b/Examples/Widgets/listbox.csd
@@ -1,4 +1,4 @@
 <Cabbage>
-form size(400, 500), caption("Untitled"), pluginid("plu1"), colour(39, 40, 34)
+form size(400, 500), caption("Untitled"), pluginid("LtBx"), colour(39, 40, 34)
 listbox bounds(10, 16, 300, 200), channel("comps"), file("Compositions.txt"), colour("yellow"), fontcolour("black")
 </Cabbage>

--- a/Examples/Widgets/meter.csd
+++ b/Examples/Widgets/meter.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Meter example") size(400, 300), colour(220, 220, 220), pluginid("def1")
+form caption("Meter example") size(400, 300), colour(220, 220, 220), pluginid("Mtr1")
 label bounds(8, 6, 368, 20), text("Basic Usage"), fontcolour("black")
 vmeter bounds(116, 32, 35, 80) channel("vMeter1") value(0) overlaycolour(70, 53, 53, 255) metercolour:0(0, 255, 0, 255) metercolour:1(0, 103, 171, 255) metercolour:2(23, 0, 123, 255) outlinethickness(2) 
 vmeter bounds(156, 32, 35, 80) channel("vMeter2") value(0) overlaycolour(70, 53, 53, 255) metercolour:0(0, 255, 0, 255) metercolour:1(0, 103, 171, 255) metercolour:2(23, 0, 123, 255) outlinethickness(2) 

--- a/Examples/Widgets/signaldisplay.csd
+++ b/Examples/Widgets/signaldisplay.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Signaldisplay Example") size(400, 300), colour(220, 220, 220), pluginid("def1")
+form caption("Signaldisplay Example") size(400, 300), colour(220, 220, 220), pluginid("SDis")
 label bounds(8, 6, 368, 20), text("Basic Usage"), fontcolour("black")
 signaldisplay bounds(8, 30, 380, 170), colour("lime"), backgroundcolour("black"), displaytype("waveform"), signalvariable("aSig")
 </Cabbage>

--- a/Examples/Widgets/sliders.csd
+++ b/Examples/Widgets/sliders.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Slider Example") size(400, 300), colour(220, 220, 220), pluginid("def1")
+form caption("Slider Example") size(400, 300), colour(220, 220, 220), pluginid("Slid")
 label bounds(8, 6, 368, 20), text("Basic Usage"), fontcolour("black")
 hslider bounds(8, 38, 369, 50), channel("gain"), text("Gain") range(0, 1, 0, 1, 0.001) fontcolour(91, 46, 46, 255) textcolour(29, 29, 29, 255)
 groupbox bounds(8, 110, 380, 177), text("Randomly Updated Identifiers")

--- a/Examples/Widgets/soundfiler.csd
+++ b/Examples/Widgets/soundfiler.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form size(400, 500), caption("Soundfiler"), size(400, 300), colour(220, 220, 220), pluginid("def1")
+form size(400, 500), caption("Soundfiler"), size(400, 300), colour(220, 220, 220), pluginid("SndF")
 soundfiler bounds(10,10, 380, 200), identchannel("soundfilerIdent")
 filebutton bounds(10, 215, 100, 30), channel("openFile"), text("Browse")
 </Cabbage>

--- a/Examples/Widgets/textbox.csd
+++ b/Examples/Widgets/textbox.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Textbox Example") size(400, 300), colour(220, 220, 220), pluginid("def1")
+form caption("Textbox Example") size(400, 300), colour(220, 220, 220), pluginid("TxB1")
 label bounds(8, 6, 368, 20), text("Basic Usage"), fontcolour("black")
 textbox bounds(10, 30, 380, 267) identchannel("widgetIdent"), file("Textbox.csd")
 </Cabbage>

--- a/Examples/Widgets/texteditor.csd
+++ b/Examples/Widgets/texteditor.csd
@@ -1,5 +1,5 @@
 <Cabbage>
-form caption("Texteditor Example") size(400, 300), colour(220, 220, 220), pluginid("def1")
+form caption("Texteditor Example") size(400, 300), colour(220, 220, 220), pluginid("TxE1")
 label bounds(8, 6, 368, 20), text("Basic Usage"), fontcolour("black")
 groupbox bounds(8, 110, 380, 177), text("Randomly Updated Identifiers")
 label bounds(12, 36, 297, 19), text("Enter some text and hit enter"), align("left") fontcolour(84, 83, 83, 255)


### PR DESCRIPTION
Needed for AudioUnit export, as all AU plugins need a unique name.