### PR TITLE
get rid of magnetic behavior in approaching handles from left to right

### DIFF
--- a/Source/Widgets/Legacy/TableManager.cpp
+++ b/Source/Widgets/Legacy/TableManager.cpp
@@ -1763,7 +1763,7 @@ void HandleComponent::mouseDrag (const MouseEvent& e)
             else if (previousX >= xPos)
                 xPos = previousX + 1;
 
-            else if (xPos + getWidth() > nextX)
+            else if (xPos > nextX)
                 xPos = nextX + 1;
         }
         else


### PR DESCRIPTION
There is a strange magnetic behavior using the gentable widget when you approach an handle from left to right. This leads to the impossibility to draw a steep curve on the far right of the widget or to approach an handle from the left, so it's very annoying.

With this fix there is no longer the magnetic behavior.