### PR TITLE
keypressbaseoctave mods

### DIFF
--- a/Source/Audio/Plugins/CabbagePluginEditor.cpp
+++ b/Source/Audio/Plugins/CabbagePluginEditor.cpp
@@ -489,7 +489,7 @@ void CabbagePluginEditor::insertMIDIKeyboard (ValueTree cabbageWidgetData)
     {
         CabbageKeyboard* midiKeyboard;
         components.add (midiKeyboard = new CabbageKeyboard (cabbageWidgetData, processor.keyboardState));
-        midiKeyboard->setKeyPressBaseOctave (3);
+        //midiKeyboard->setKeyPressBaseOctave (3); // <-- now you can set this with 'keypressbaseoctave' identifier
         addToEditorAndMakeVisible (midiKeyboard, cabbageWidgetData);
         addMouseListenerAndSetVisibility (midiKeyboard, cabbageWidgetData);
         keyboardCount++;

--- a/Source/CabbageIds.h
+++ b/Source/CabbageIds.h
@@ -281,6 +281,7 @@ public:
         add ("trackerinsideradius");
         add ("surrogatelinenumber");
         add ("mouseoeverkeycolour");
+	add ("keypressbaseoctave");
         add ("keyseparatorcolour");
         add ("amprange_quantise");
         add ("currentnotecolour");
@@ -533,6 +534,7 @@ namespace CabbageIdentifierIds
 	static const Identifier importfiles = "importfiles";
 	static const Identifier increment = "increment";
 	static const Identifier items = "items";
+	static const Identifier keypressbaseoctave = "keypressbaseoctave";
 	static const Identifier keyseparatorcolour = "keyseparatorcolour";
 	static const Identifier keywidth = "keywidth";
 	static const Identifier kind = "kind";

--- a/Source/Widgets/CabbageKeyboard.cpp
+++ b/Source/Widgets/CabbageKeyboard.cpp
@@ -32,11 +32,11 @@ CabbageKeyboard::CabbageKeyboard (ValueTree wData, MidiKeyboardState& state)
 
     setLowestVisibleKey (CabbageWidgetData::getNumProp (wData, CabbageIdentifierIds::value));
     setOctaveForMiddleC (CabbageWidgetData::getNumProp (wData, CabbageIdentifierIds::middlec));
+    setKeyPressBaseOctave (CabbageWidgetData::getNumProp (wData, CabbageIdentifierIds::keypressbaseoctave)); // octave num. in [0, 10]
     setKeyWidth (keyWidth);
     setScrollButtonsVisible (scrollbars == 1 ? true : false);
-
+    
     updateColours(wData);
-
 
 }
 

--- a/Source/Widgets/CabbageWidgetData.cpp
+++ b/Source/Widgets/CabbageWidgetData.cpp
@@ -355,6 +355,7 @@ void CabbageWidgetData::setCustomWidgetState (ValueTree widgetData, String lineO
             case HashStringToInt ("surrogatelinenumber"):
             case HashStringToInt ("imgdebug"):
             case HashStringToInt ("middlec"):
+            case HashStringToInt ("keypressbaseoctave"):
             case HashStringToInt ("fill"):
             case HashStringToInt ("updaterate"):
             case HashStringToInt ("keywidth"):

--- a/Source/Widgets/CabbageWidgetDataInitMethods.cpp
+++ b/Source/Widgets/CabbageWidgetDataInitMethods.cpp
@@ -299,6 +299,7 @@ void CabbageWidgetData::setKeyboardProperties (ValueTree widgetData, int ID)
     setProperty (widgetData, CabbageIdentifierIds::height, 100);
     setProperty (widgetData, CabbageIdentifierIds::value, 60);
     setProperty (widgetData, CabbageIdentifierIds::middlec, 3);
+    setProperty (widgetData, CabbageIdentifierIds::keypressbaseoctave, 3);
     setProperty (widgetData, CabbageIdentifierIds::type, "keyboard");
     setProperty (widgetData, CabbageIdentifierIds::name, "keyboard");
     setProperty (widgetData, CabbageIdentifierIds::kind, "horizontal");

--- a/Source/Widgets/Legacy/TableManager.cpp
+++ b/Source/Widgets/Legacy/TableManager.cpp
@@ -1763,7 +1763,7 @@ void HandleComponent::mouseDrag (const MouseEvent& e)
             else if (previousX >= xPos)
                 xPos = previousX + 1;
 
-            else if (xPos + getWidth() > nextX)
+            else if (xPos > nextX)
                 xPos = nextX + 1;
         }
         else


### PR DESCRIPTION
Mods to let the user change the base note that is played pressing a key on the PC keyboard with the added identifier 'keypressbaseoctave' in the keyboard widget.