### PR TITLE
set titlebarcolour colour of the plugin window 

### DIFF
--- a/Source/Audio/Graph/PluginWindow.h
+++ b/Source/Audio/Graph/PluginWindow.h
@@ -51,10 +51,12 @@ public:
          node (n), type (t)
     {
         setSize (400, 300);
-
-        if (auto* ui = createProcessorEditor (*node->getProcessor(), type))
-            setContentOwned (ui, true);
-
+		
+		if (auto* ui = createProcessorEditor(*node->getProcessor(), type))
+		{
+			setContentOwned(ui, true);
+			setBackgroundColour( ((CabbagePluginEditor*)ui)->titlebarColour ); // <-- set titlebar colour of the plugin window
+		}
        #if JUCE_IOS || JUCE_ANDROID
         auto screenBounds = Desktop::getInstance().getDisplays().getTotalBounds (true).toFloat();
 

--- a/Source/Audio/Plugins/CabbagePluginEditor.cpp
+++ b/Source/Audio/Plugins/CabbagePluginEditor.cpp
@@ -175,11 +175,12 @@ void CabbagePluginEditor::setupWindow (ValueTree widgetData)
     showScrollbars = bool(CabbageWidgetData::getNumProp (widgetData, CabbageIdentifierIds::scrollbars));
     const int height = CabbageWidgetData::getNumProp (widgetData, CabbageIdentifierIds::height);
     const String backgroundColourString = CabbageWidgetData::getStringProp (widgetData, CabbageIdentifierIds::colour);
+    const String titlebarColourString = CabbageWidgetData::getStringProp(widgetData, CabbageIdentifierIds::titlebarcolour);
     lookAndFeel.setDefaultFont(CabbageWidgetData::getStringProp (widgetData, CabbageIdentifierIds::typeface));
 
     backgroundColour = Colour::fromString (backgroundColourString);
-    lookAndFeel.setColour(ScrollBar::backgroundColourId, backgroundColour);
-    mainComponent.setColour (backgroundColour);
+    titlebarColour	 = Colour::fromString (titlebarColourString);
+    lookAndFeel.setColour(ScrollBar::backgroundColourId, backgroundColour);  
     mainComponent.setColour (backgroundColour);
     instrumentBounds.setXY(width, height);
     setSize (width, height);

--- a/Source/Audio/Plugins/CabbagePluginEditor.h
+++ b/Source/Audio/Plugins/CabbagePluginEditor.h
@@ -195,6 +195,7 @@ public:
         return editModeEnabled;
     }
     Colour backgroundColour;
+    Colour titlebarColour;
 
     //---- popup plant window ----
     class PopupDocumentWindow : public DocumentWindow, public ChangeBroadcaster

--- a/Source/Widgets/CabbageWidgetDataInitMethods.cpp
+++ b/Source/Widgets/CabbageWidgetDataInitMethods.cpp
@@ -36,7 +36,7 @@ void CabbageWidgetData::setFormProperties (ValueTree widgetData, int ID)
     setProperty (widgetData, CabbageIdentifierIds::identchannel, "");
     setProperty (widgetData, CabbageIdentifierIds::visible, 1);
     setProperty (widgetData, CabbageIdentifierIds::scrollbars, 0);
-    setProperty (widgetData, CabbageIdentifierIds::titlebarcolour, "");
+    setProperty (widgetData, CabbageIdentifierIds::titlebarcolour, CabbageUtilities::getBackgroundSkin().toString());
     setProperty (widgetData, CabbageIdentifierIds::channeltype, "number");
 
     setProperty (widgetData, CabbageIdentifierIds::fontcolour, "");


### PR DESCRIPTION
With this mod you can add a 'titlebarcolour' identifier to the form widget to set the titlebar colour independently of the 'form' background colour.