### PR TITLE
added fontcolour and titlebargradient identifiers to the form widget

### DIFF
--- a/Source/Audio/Graph/PluginWindow.h
+++ b/Source/Audio/Graph/PluginWindow.h
@@ -42,7 +42,7 @@ public:
         audioIO,
         numTypes
     };
-
+	
     PluginWindow (AudioProcessorGraph::Node* n, Type t, OwnedArray<PluginWindow>& windowList)
        : DocumentWindow (n->getProcessor()->getName(),
                          LookAndFeel::getDefaultLookAndFeel().findColour (ResizableWindow::backgroundColourId),
@@ -51,11 +51,16 @@ public:
          node (n), type (t)
     {
         setSize (400, 300);
-		
+        setLookAndFeel (&pluginWindowLookAndFeel);
+
 		if (auto* ui = createProcessorEditor(*node->getProcessor(), type))
 		{
 			setContentOwned(ui, true);
 			setBackgroundColour( ((CabbagePluginEditor*)ui)->titlebarColour ); // <-- set titlebar colour of the plugin window
+			
+			pluginWindowLookAndFeel.titlebarContrastingGradient = ((CabbagePluginEditor*)ui)->titlebarGradientAmount;
+			if ( ((CabbagePluginEditor*)ui)->defaultFontColour == false )
+				setColour( DocumentWindow::textColourId, ((CabbagePluginEditor*)ui)->fontColour ); // <-- set customized titlebar font colour
 		}
        #if JUCE_IOS || JUCE_ANDROID
         auto screenBounds = Desktop::getInstance().getDisplays().getTotalBounds (true).toFloat();
@@ -79,6 +84,7 @@ public:
     {
         node->getProcessor()->editorBeingDeleted(node->getProcessor()->getActiveEditor());
         clearContentComponent();
+        setLookAndFeel (nullptr);
     }
 
     void moved() override
@@ -103,6 +109,8 @@ public:
 
 
 private:
+    CabbageLookAndFeel2 pluginWindowLookAndFeel;
+
     float getDesktopScaleFactor() const override     { return 1.0f; }
 
     static AudioProcessorEditor* createProcessorEditor (AudioProcessor& processor, PluginWindow::Type type)

--- a/Source/Audio/Plugins/CabbagePluginEditor.cpp
+++ b/Source/Audio/Plugins/CabbagePluginEditor.cpp
@@ -176,7 +176,7 @@ void CabbagePluginEditor::setupWindow (ValueTree widgetData)
     const int height = CabbageWidgetData::getNumProp (widgetData, CabbageIdentifierIds::height);
     const String backgroundColourString = CabbageWidgetData::getStringProp (widgetData, CabbageIdentifierIds::colour);
     const String titlebarColourString = CabbageWidgetData::getStringProp(widgetData, CabbageIdentifierIds::titlebarcolour);
-    titlebarGradientAmount = CabbageWidgetData::getNumProp(widgetData, CabbageIdentifierIds::titlebargradientamount);
+    titlebarGradientAmount = CabbageWidgetData::getNumProp(widgetData, CabbageIdentifierIds::titlebargradient);
     const String fontColourString = CabbageWidgetData::getStringProp(widgetData, CabbageIdentifierIds::fontcolour);
     lookAndFeel.setDefaultFont(CabbageWidgetData::getStringProp (widgetData, CabbageIdentifierIds::typeface));
 

--- a/Source/Audio/Plugins/CabbagePluginEditor.cpp
+++ b/Source/Audio/Plugins/CabbagePluginEditor.cpp
@@ -176,10 +176,17 @@ void CabbagePluginEditor::setupWindow (ValueTree widgetData)
     const int height = CabbageWidgetData::getNumProp (widgetData, CabbageIdentifierIds::height);
     const String backgroundColourString = CabbageWidgetData::getStringProp (widgetData, CabbageIdentifierIds::colour);
     const String titlebarColourString = CabbageWidgetData::getStringProp(widgetData, CabbageIdentifierIds::titlebarcolour);
+    titlebarGradientAmount = CabbageWidgetData::getNumProp(widgetData, CabbageIdentifierIds::titlebargradientamount);
+    const String fontColourString = CabbageWidgetData::getStringProp(widgetData, CabbageIdentifierIds::fontcolour);
     lookAndFeel.setDefaultFont(CabbageWidgetData::getStringProp (widgetData, CabbageIdentifierIds::typeface));
 
     backgroundColour = Colour::fromString (backgroundColourString);
-    titlebarColour	 = Colour::fromString (titlebarColourString);
+    titlebarColour   = Colour::fromString (titlebarColourString);
+    fontColour       = Colour::fromString (fontColourString);
+
+    if (fontColourString != "")
+        defaultFontColour = false;
+
     lookAndFeel.setColour(ScrollBar::backgroundColourId, backgroundColour);  
     mainComponent.setColour (backgroundColour);
     instrumentBounds.setXY(width, height);

--- a/Source/Audio/Plugins/CabbagePluginEditor.h
+++ b/Source/Audio/Plugins/CabbagePluginEditor.h
@@ -196,6 +196,9 @@ public:
     }
     Colour backgroundColour;
     Colour titlebarColour;
+    Colour fontColour;
+    bool defaultFontColour = true;
+    float titlebarGradientAmount;
 
     //---- popup plant window ----
     class PopupDocumentWindow : public DocumentWindow, public ChangeBroadcaster

--- a/Source/CabbageIds.h
+++ b/Source/CabbageIds.h
@@ -273,6 +273,7 @@ public:
     {
         add ("scrubberposition_sample");
         add ("scrubberposition_table");
+        add ("titlebargradientamount");
         add ("tablebackgroundcolour");
         add ("arrowbackgroundcolour");
         add ("amprange_tablenumber");
@@ -281,7 +282,7 @@ public:
         add ("trackerinsideradius");
         add ("surrogatelinenumber");
         add ("mouseoeverkeycolour");
-	add ("keypressbaseoctave");
+        add ("keypressbaseoctave");
         add ("keyseparatorcolour");
         add ("amprange_quantise");
         add ("currentnotecolour");
@@ -624,6 +625,7 @@ namespace CabbageIdentifierIds
 	static const Identifier textboxoutlinecolour = "textboxoutlinecolour";
 	static const Identifier textcolour = "textcolour";
 	static const Identifier titlebarcolour = "titlebarcolour";
+	static const Identifier titlebargradientamount = "titlebargradientamount";
     static const Identifier tofront = "tofront";
     static const Identifier top = "top";
 	static const Identifier trackercolour = "trackercolour";

--- a/Source/CabbageIds.h
+++ b/Source/CabbageIds.h
@@ -273,7 +273,6 @@ public:
     {
         add ("scrubberposition_sample");
         add ("scrubberposition_table");
-        add ("titlebargradientamount");
         add ("tablebackgroundcolour");
         add ("arrowbackgroundcolour");
         add ("amprange_tablenumber");
@@ -291,13 +290,14 @@ public:
         add ("activecellcolour");
         add ("outlinethickness");
         add ("scrubberposition");
-        add ("whitenotecolour");
+        add ("titlebargradient");
+	add ("whitenotecolour");
         add ("blacknotecolour");
         add ("highlightcolour");
         add ("tablegridcolour");
         add ("backgroundcolor");
         add ("showstepnumbers");
-		add ("titlebarcolour");
+	add ("titlebarcolour");
         add ("tablegridcolor");
         add ("signalvariable");
         add ("overlaycolour");
@@ -625,7 +625,7 @@ namespace CabbageIdentifierIds
 	static const Identifier textboxoutlinecolour = "textboxoutlinecolour";
 	static const Identifier textcolour = "textcolour";
 	static const Identifier titlebarcolour = "titlebarcolour";
-	static const Identifier titlebargradientamount = "titlebargradientamount";
+	static const Identifier titlebargradient = "titlebargradient";
     static const Identifier tofront = "tofront";
     static const Identifier top = "top";
 	static const Identifier trackercolour = "trackercolour";

--- a/Source/CabbageIds.h
+++ b/Source/CabbageIds.h
@@ -291,13 +291,13 @@ public:
         add ("outlinethickness");
         add ("scrubberposition");
         add ("titlebargradient");
-	add ("whitenotecolour");
+        add ("whitenotecolour");
         add ("blacknotecolour");
         add ("highlightcolour");
         add ("tablegridcolour");
         add ("backgroundcolor");
         add ("showstepnumbers");
-	add ("titlebarcolour");
+        add ("titlebarcolour");
         add ("tablegridcolor");
         add ("signalvariable");
         add ("overlaycolour");
@@ -356,8 +356,8 @@ public:
         add ("arraysize");
         add ("increment");
         add ("namespace");
-		add ("rowprefix");
-		add ("colprefix");
+        add ("rowprefix");
+        add ("colprefix");
         add ("populate");
         add ("keywidth");
         add ("pluginid");

--- a/Source/LookAndFeel/CabbageLookAndFeel2.cpp
+++ b/Source/LookAndFeel/CabbageLookAndFeel2.cpp
@@ -105,7 +105,7 @@ void CabbageLookAndFeel2::drawDocumentWindowTitleBar (DocumentWindow& window, Gr
 	}
 
 	if (window.isColourSpecified (DocumentWindow::textColourId) || isColourSpecified (DocumentWindow::textColourId))
-		g.setColour (window.findColour (DocumentWindow::textColourId));
+		g.setColour (window.findColour (DocumentWindow::textColourId).contrasting (isActive ? 0.0f : 0.4f));
 	else
 		g.setColour (window.getBackgroundColour().contrasting (isActive ? 0.7f : 0.4f));
 

--- a/Source/LookAndFeel/CabbageLookAndFeel2.cpp
+++ b/Source/LookAndFeel/CabbageLookAndFeel2.cpp
@@ -61,6 +61,57 @@ void CabbageLookAndFeel2::setDefaultFont(File fontFile)
 //    else
 //        customFont = CabbageUtilities::getComponentFont();
 }
+
+void CabbageLookAndFeel2::drawDocumentWindowTitleBar (DocumentWindow& window, Graphics& g,
+	int w, int h, int titleSpaceX, int titleSpaceW,
+	const Image* icon, bool drawTitleTextOnLeft)
+{
+	if (w * h == 0)
+		return;
+
+	const bool isActive = window.isActiveWindow();
+
+	g.setGradientFill (ColourGradient::vertical (window.getBackgroundColour(), 0,
+		window.getBackgroundColour().contrasting (isActive ? titlebarContrastingGradient : std::max(0.0f, titlebarContrastingGradient - 0.10f)), (float)h));
+	g.fillAll();
+
+	Font font (h * 0.65f, Font::bold);
+	g.setFont (font);
+
+	int textW = font.getStringWidth (window.getName());
+	int iconW = 0;
+	int iconH = 0;
+
+	if (icon != nullptr)
+	{
+		iconH = (int)font.getHeight();
+		iconW = icon->getWidth() * iconH / icon->getHeight() + 4;
+	}
+
+	textW = jmin (titleSpaceW, textW + iconW);
+	int textX = drawTitleTextOnLeft ? titleSpaceX
+		: jmax (titleSpaceX, (w - textW) / 2);
+
+	if (textX + textW > titleSpaceX + titleSpaceW)
+		textX = titleSpaceX + titleSpaceW - textW;
+
+	if (icon != nullptr)
+	{
+		g.setOpacity (isActive ? 1.0f : 0.6f);
+		g.drawImageWithin (*icon, textX, (h - iconH) / 2, iconW, iconH,
+			RectanglePlacement::centred, false);
+		textX += iconW;
+		textW -= iconW;
+	}
+
+	if (window.isColourSpecified (DocumentWindow::textColourId) || isColourSpecified (DocumentWindow::textColourId))
+		g.setColour (window.findColour (DocumentWindow::textColourId));
+	else
+		g.setColour (window.getBackgroundColour().contrasting (isActive ? 0.7f : 0.4f));
+
+	g.drawText (window.getName(), textX, 0, textW, h, Justification::centredLeft, true);
+}
+
 //=========== ComboBox ============================================================================
 void CabbageLookAndFeel2::drawComboBox (Graphics& g, int width, int height, bool /*isButtonDown*/,
                                         int /*buttonX*/,

--- a/Source/LookAndFeel/CabbageLookAndFeel2.h
+++ b/Source/LookAndFeel/CabbageLookAndFeel2.h
@@ -20,6 +20,12 @@ public:
     CabbageLookAndFeel2();
     ~CabbageLookAndFeel2() {};
 
+    float titlebarContrastingGradient; // 0.0: no gradient in the titlebar - 1.0: max contrasting gradient
+
+    void drawDocumentWindowTitleBar (DocumentWindow& window, Graphics& g,
+		int w, int h, int titleSpaceX, int titleSpaceW,
+		const Image* icon, bool drawTitleTextOnLeft) override;
+	
     void drawToggleButton (Graphics& g, ToggleButton& button, bool isMouseOverButton, bool isButtonDown) override;
 
     void drawRotarySlider (Graphics& g, int x, int y, int width, int height, float sliderPosProportional, float rotaryStartAngle, float rotaryEndAngle, Slider& slider)override;
@@ -89,7 +95,6 @@ public:
 private:
 
     Font customFont;
-
 
 };
 

--- a/Source/Widgets/CabbageWidgetData.cpp
+++ b/Source/Widgets/CabbageWidgetData.cpp
@@ -288,6 +288,10 @@ void CabbageWidgetData::setCustomWidgetState (ValueTree widgetData, String lineO
         switch (HashStringToInt (identifier.toStdString().c_str()))
         {
             //======== strings ===============================
+            case HashStringToInt ("caption"):
+				setProperty (widgetData, identifier, strTokens[0]);
+				break;
+
             case HashStringToInt ("kind"):
             case HashStringToInt ("file"):
             case HashStringToInt ("imgpath"):
@@ -303,7 +307,6 @@ void CabbageWidgetData::setCustomWidgetState (ValueTree widgetData, String lineO
             case HashStringToInt ("align"):
             case HashStringToInt ("displaytype"):
             case HashStringToInt ("name"):
-            case HashStringToInt ("caption"):
             case HashStringToInt ("plant"):
             case HashStringToInt ("show"):
             case HashStringToInt ("child"):
@@ -311,9 +314,7 @@ void CabbageWidgetData::setCustomWidgetState (ValueTree widgetData, String lineO
             case HashStringToInt ("manufacturer"):
             case HashStringToInt ("logger"):
             case HashStringToInt ("namespace"):
-
                 setProperty (widgetData, identifier, (identifier.contains("fix") ? strTokens[0] : strTokens[0].trim()));
-                break;
                 break;
 
             case HashStringToInt ("channel"):

--- a/Source/Widgets/CabbageWidgetData.cpp
+++ b/Source/Widgets/CabbageWidgetData.cpp
@@ -288,10 +288,6 @@ void CabbageWidgetData::setCustomWidgetState (ValueTree widgetData, String lineO
         switch (HashStringToInt (identifier.toStdString().c_str()))
         {
             //======== strings ===============================
-            case HashStringToInt ("caption"):
-				setProperty (widgetData, identifier, strTokens[0]);
-				break;
-
             case HashStringToInt ("kind"):
             case HashStringToInt ("file"):
             case HashStringToInt ("imgpath"):
@@ -307,6 +303,7 @@ void CabbageWidgetData::setCustomWidgetState (ValueTree widgetData, String lineO
             case HashStringToInt ("align"):
             case HashStringToInt ("displaytype"):
             case HashStringToInt ("name"):
+            case HashStringToInt ("caption"):
             case HashStringToInt ("plant"):
             case HashStringToInt ("show"):
             case HashStringToInt ("child"):
@@ -387,6 +384,7 @@ void CabbageWidgetData::setCustomWidgetState (ValueTree widgetData, String lineO
             case HashStringToInt ("wrap"):
             case HashStringToInt ("readonly"):
             case HashStringToInt ("scrollbars"):
+            case HashStringToInt ("titlebargradientamount"):
                 if (getStringProp (widgetData, CabbageIdentifierIds::channeltype) == "string")
                     setProperty (widgetData, identifier, strTokens[0].trim());
                 else

--- a/Source/Widgets/CabbageWidgetData.cpp
+++ b/Source/Widgets/CabbageWidgetData.cpp
@@ -384,7 +384,7 @@ void CabbageWidgetData::setCustomWidgetState (ValueTree widgetData, String lineO
             case HashStringToInt ("wrap"):
             case HashStringToInt ("readonly"):
             case HashStringToInt ("scrollbars"):
-            case HashStringToInt ("titlebargradientamount"):
+            case HashStringToInt ("titlebargradient"):
                 if (getStringProp (widgetData, CabbageIdentifierIds::channeltype) == "string")
                     setProperty (widgetData, identifier, strTokens[0].trim());
                 else

--- a/Source/Widgets/CabbageWidgetDataInitMethods.cpp
+++ b/Source/Widgets/CabbageWidgetDataInitMethods.cpp
@@ -37,7 +37,7 @@ void CabbageWidgetData::setFormProperties (ValueTree widgetData, int ID)
     setProperty (widgetData, CabbageIdentifierIds::visible, 1);
     setProperty (widgetData, CabbageIdentifierIds::scrollbars, 0);
     setProperty (widgetData, CabbageIdentifierIds::titlebarcolour, CabbageUtilities::getBackgroundSkin().toString());
-    setProperty (widgetData, CabbageIdentifierIds::titlebargradientamount, 0.15f);
+    setProperty (widgetData, CabbageIdentifierIds::titlebargradient, 0.15f);
     setProperty (widgetData, CabbageIdentifierIds::channeltype, "number");
 
     setProperty (widgetData, CabbageIdentifierIds::fontcolour, "");

--- a/Source/Widgets/CabbageWidgetDataInitMethods.cpp
+++ b/Source/Widgets/CabbageWidgetDataInitMethods.cpp
@@ -37,6 +37,7 @@ void CabbageWidgetData::setFormProperties (ValueTree widgetData, int ID)
     setProperty (widgetData, CabbageIdentifierIds::visible, 1);
     setProperty (widgetData, CabbageIdentifierIds::scrollbars, 0);
     setProperty (widgetData, CabbageIdentifierIds::titlebarcolour, CabbageUtilities::getBackgroundSkin().toString());
+    setProperty (widgetData, CabbageIdentifierIds::titlebargradientamount, 0.15f);
     setProperty (widgetData, CabbageIdentifierIds::channeltype, "number");
 
     setProperty (widgetData, CabbageIdentifierIds::fontcolour, "");


### PR DESCRIPTION
Note:
- with no fontcolour identifier, the colour of the titlebar font will be automatically determined based on the background color (like before this mod).
- with a fontcolour alpha set to 0, the window title will be hidden, but the plugin will always be named with the caption string or an "Untitled" name.
- <strike>titlebargradientamount</strike> titlebargradient has to be in the range [0..1]. It sets the amount of contrasted gradient for the fill of the titlebar background. 0 means NO GRADIENT. 1 means MAX CONTRAST IN THE GRADIENT. The default Juce value is 0.15 that creates a very light gradient when the plugin window is focused.

EDIT: "titlebargradientamount" identifier changed in a more convenient "titlebargradient".