### PR TITLE
fix for CabbageEffectNam in titlebar

### DIFF
--- a/Source/Application/CabbageMainComponent.cpp
+++ b/Source/Application/CabbageMainComponent.cpp
@@ -285,7 +285,12 @@ void CabbageMainComponent::handleFileTabs (DrawableButton* drawableButton)
             {
                 if (auto f = audioGraph->graph.getNodeForId (nodeId))
                     if (auto* w = audioGraph->getOrCreateWindowFor (f, PluginWindow::Type::normal))
+                    {
+                        CabbagePluginProcessor* cabbagePlugin = getCabbagePluginProcessor();
+                        String pluginName = cabbagePlugin->getPluginName();
+                        w->setName (pluginName.length() > 0 ? pluginName : "Plugin has no name?");
                         w->toFront (true);
+                    }
             }
 
         }


### PR DESCRIPTION
After you start a csd file, if you close your plugin window (without stop it) and then click on the icon in the tabs to make the plugin window reappear, there will be a "CabbageEffectNam" in the titlebar text, instead of the form caption. Fixed.