### PR TITLE
Fix x no Cabbage section

### DIFF
--- a/Source/Audio/Filters/FilterGraph.h
+++ b/Source/Audio/Filters/FilterGraph.h
@@ -76,6 +76,8 @@ public:
 			if (CabbageWidgetData::getStringProp(temp, CabbageIdentifierIds::type) == CabbageWidgetTypes::form)
 				return CabbageWidgetData::getStringProp(temp, CabbageIdentifierIds::caption);
 		}
+
+        return "";
 	}
 
 	static const PluginDescription getPluginDescriptor(AudioProcessorGraph::NodeID nodeId, String inputFile)

--- a/Source/Audio/Plugins/GenericCabbageEditor.cpp
+++ b/Source/Audio/Plugins/GenericCabbageEditor.cpp
@@ -75,7 +75,7 @@ GenericCabbageEditor::GenericCabbageEditor (AudioProcessor& parent)
 
 GenericCabbageEditor::~GenericCabbageEditor()
 {
-
+    setLookAndFeel (nullptr);
 }
 
 void GenericCabbageEditor::resized()


### PR DESCRIPTION
Cabbage goes in crash when the csd has no `<Cabbage>...</Cabbage>` section or the section exists but it has no form element. Fixed.