### PR TITLE
Fix x Show Plugin Editor button

### DIFF
--- a/Source/Application/CabbageMainComponent.cpp
+++ b/Source/Application/CabbageMainComponent.cpp
@@ -301,6 +301,7 @@ void CabbageMainComponent::handleFileTabs (DrawableButton* drawableButton)
                         String pluginName = cabbagePlugin->getPluginName();
                         w->setName (pluginName.length() > 0 ? pluginName : "Plugin has no name?");
                         w->toFront (true);
+                        w->setVisible (true);
                     }
             }
 


### PR DESCRIPTION
The "Show Plugin Editor" button didn't work when the plugin window was closed with the (X) top-right button in its titlebar. FIXED.