### PR TITLE
Some fixes + fallback on original png icons if no svg 

### DIFF
--- a/Source/Application/CabbageMainComponent.cpp
+++ b/Source/Application/CabbageMainComponent.cpp
@@ -667,6 +667,7 @@ void CabbageMainComponent::addFileTab (File file)
     fileButton->setToggleState (true, dontSendNotification);
     currentFileIndex = fileTabs.size() - 1;
     fileButton->addButtonListeners (this);
+    fileButton->setButtonColour(CabbageSettings::getColourFromValueTree(cabbageSettings->getValueTree(), CabbageColourIds::fileTabButton, Colour(50, 50, 50)));
 
     for ( auto button : fileTabs )
     {

--- a/Source/Application/CabbageMainComponent.cpp
+++ b/Source/Application/CabbageMainComponent.cpp
@@ -344,7 +344,9 @@ void CabbageMainComponent::handleFileTabs (DrawableButton* drawableButton)
                     if (auto* w = getFilterGraph()->getOrCreateWindowFor (f, PluginWindow::Type::normal))
                     {
                         CabbagePluginProcessor* cabbagePlugin = getCabbagePluginProcessor();
-                        String pluginName = cabbagePlugin->getPluginName();
+                        String pluginName = "";
+                        if (cabbagePlugin)
+                            pluginName = cabbagePlugin->getPluginName();
                         w->setName (pluginName.length() > 0 ? pluginName : "Plugin has no name?");
                         w->toFront (true);
                         w->setVisible (true);

--- a/Source/Application/CabbageToolbarFactory.cpp
+++ b/Source/Application/CabbageToolbarFactory.cpp
@@ -83,54 +83,66 @@ const String getSVGTextFromFile (const String filename)
 ToolbarItemComponent* CabbageToolbarFactory::createItem (int itemId)
 {
 
+    ToolbarButton *button = nullptr;
+
     switch (itemId)
     {
     case doc_new:
-        //return createButtonFromPNG (itemId, "new", CabbageBinaryData::documentnew_png, CabbageBinaryData::documentnew_pngSize);
-        return createButtonFromSVG (itemId, "new", getSVGTextFromFile (iconsPath + "/document-new.svg"));
+        button = createButtonFromSVG (itemId, "new", getSVGTextFromFile (iconsPath + "/document-new.svg"));
+        if (!button)
+            button = createButtonFromPNG (itemId, "new", CabbageBinaryData::documentnew_png, CabbageBinaryData::documentnew_pngSize);
         //return createButtonFromSVG (itemId, "new", getSVGTextFromMemory (CabbageBinaryData::documentnew_svg, CabbageBinaryData::documentnew_svgSize));
-
+        break;
     case doc_open:
-        //return createButtonFromPNG (itemId, "open", CabbageBinaryData::documentopen_png, CabbageBinaryData::documentopen_pngSize);
-        return createButtonFromSVG (itemId, "open", getSVGTextFromFile (iconsPath + "/document-open.svg"));
+        button = createButtonFromSVG (itemId, "open", getSVGTextFromFile (iconsPath + "/document-open.svg"));
+        if (!button)
+            button = createButtonFromPNG (itemId, "open", CabbageBinaryData::documentopen_png, CabbageBinaryData::documentopen_pngSize);
         //return createButtonFromSVG (itemId, "open", getSVGTextFromMemory (CabbageBinaryData::documentopen_svg, CabbageBinaryData::documentopen_svgSize));
-
+        break;
     case doc_save:
-        //return createButtonFromPNG (itemId, "save", CabbageBinaryData::documentsave_png, CabbageBinaryData::documentsave_pngSize);
-        return createButtonFromSVG (itemId, "save", getSVGTextFromFile (iconsPath + "/document-save.svg"));
+        button = createButtonFromSVG (itemId, "save", getSVGTextFromFile (iconsPath + "/document-save.svg"));
+        if (!button)
+            button = createButtonFromPNG (itemId, "save", CabbageBinaryData::documentsave_png, CabbageBinaryData::documentsave_pngSize);
         //return createButtonFromSVG (itemId, "save", getSVGTextFromMemory (CabbageBinaryData::documentsave_svg, CabbageBinaryData::documentsave_svgSize));
-
+        break;
     case doc_saveAs:
-        //return createButtonFromPNG (itemId, "save as", CabbageBinaryData::documentsaveas_png, CabbageBinaryData::documentsaveas_pngSize);
-        return createButtonFromSVG (itemId, "save as", getSVGTextFromFile (iconsPath + "/document-save-as.svg"));
+        button = createButtonFromSVG (itemId, "save as", getSVGTextFromFile (iconsPath + "/document-save-as.svg"));
+        if (!button)
+            button = createButtonFromPNG (itemId, "save as", CabbageBinaryData::documentsaveas_png, CabbageBinaryData::documentsaveas_pngSize);
         //return createButtonFromSVG (itemId, "save as", getSVGTextFromMemory (CabbageBinaryData::documentsaveas_svg, CabbageBinaryData::documentsaveas_svgSize));
-
+        break;
     case edit_copy:
-        //return createButtonFromSVG (itemId, "copy", getSVGTextFromMemory (CabbageBinaryData::editcopy_svg, CabbageBinaryData::editcopy_svgSize));
-        return createButtonFromSVG (itemId, "copy", getSVGTextFromFile (iconsPath + "/edit-copy.svg"));
-
+        button = createButtonFromSVG (itemId, "copy", getSVGTextFromFile (iconsPath + "/edit-copy.svg"));
+        if (!button)
+            button = createButtonFromSVG (itemId, "copy", getSVGTextFromMemory (CabbageBinaryData::editcopy_svg, CabbageBinaryData::editcopy_svgSize));
+        break;
     case edit_cut:
-        //return createButtonFromPNG (itemId, "cut", CabbageBinaryData::editcut_png, CabbageBinaryData::editcut_pngSize);
-        return createButtonFromSVG (itemId, "cut", getSVGTextFromFile (iconsPath + "/edit-cut.svg"));
+        button = createButtonFromSVG (itemId, "cut", getSVGTextFromFile (iconsPath + "/edit-cut.svg"));
+        if (!button)
+            button = createButtonFromPNG (itemId, "cut", CabbageBinaryData::editcut_png, CabbageBinaryData::editcut_pngSize);
         //return createButtonFromSVG (itemId, "cut", getSVGTextFromMemory (CabbageBinaryData::editcut_svg, CabbageBinaryData::editcut_svgSize));
-
+        break;
     case edit_paste:
-        //return createButtonFromPNG (itemId, "paste", CabbageBinaryData::editpaste_png, CabbageBinaryData::editpaste_pngSize);
-        return createButtonFromSVG (itemId, "paste", getSVGTextFromFile (iconsPath + "/edit-paste.svg"));
+        button = createButtonFromSVG (itemId, "paste", getSVGTextFromFile (iconsPath + "/edit-paste.svg"));
+        if (!button)
+            button = createButtonFromPNG (itemId, "paste", CabbageBinaryData::editpaste_png, CabbageBinaryData::editpaste_pngSize);
         //return createButtonFromSVG (itemId, "paste", getSVGTextFromMemory (CabbageBinaryData::editpaste_svg, CabbageBinaryData::editpaste_svgSize));
-
+        break;
     case system_prefs:
-        //return createButtonFromPNG (itemId, "settings", CabbageBinaryData::emblemsystem_png, CabbageBinaryData::emblemsystem_pngSize);
-        return createButtonFromSVG (itemId, "settings", getSVGTextFromFile (iconsPath + "/preferences-system.svg"));
+        button = createButtonFromSVG (itemId, "settings", getSVGTextFromFile (iconsPath + "/preferences-system.svg"));
+        if (!button)
+            button = createButtonFromPNG (itemId, "settings", CabbageBinaryData::emblemsystem_png, CabbageBinaryData::emblemsystem_pngSize);
         //return createButtonFromSVG (itemId, "settings", getSVGTextFromMemory (CabbageBinaryData::emblemsystem_svg, CabbageBinaryData::emblemsystem_svgSize));
-
+        break;
     case custom_comboBox:
         return (combo = new ToolbarComboBox (itemId));
 
     case toggle_play:
-        //return createToggleButtonFromPNG (itemId, "togglePlay", CabbageBinaryData::audiovolumemuted_png, CabbageBinaryData::audiovolumemuted_pngSize,
-        //                                  CabbageBinaryData::audiovolumehigh_png, CabbageBinaryData::audiovolumehigh_pngSize);
-        return createButtonFromSVG (itemId, "togglePlay", getSVGTextFromFile (iconsPath + "/audio-muted.svg"), getSVGTextFromFile (iconsPath + "/audio-on.svg"));
+        button = createButtonFromSVG (itemId, "togglePlay", getSVGTextFromFile (iconsPath + "/audio-muted.svg"), getSVGTextFromFile (iconsPath + "/audio-on.svg"));
+        if (!button)
+            button = createToggleButtonFromPNG (itemId, "togglePlay", CabbageBinaryData::audiovolumemuted_png, CabbageBinaryData::audiovolumemuted_pngSize,
+                                              CabbageBinaryData::audiovolumehigh_png, CabbageBinaryData::audiovolumehigh_pngSize);
+        break;
         //return createButtonFromSVG (itemId, "togglePlay", getSVGTextFromMemory (CabbageBinaryData::Audiovolumemuted_svg, CabbageBinaryData::Audiovolumemuted_svgSize),
         //                            getSVGTextFromMemory (CabbageBinaryData::Audiovolumehigh_svg, CabbageBinaryData::Audiovolumehigh_svgSize));
 
@@ -138,7 +150,7 @@ ToolbarItemComponent* CabbageToolbarFactory::createItem (int itemId)
         break;
     }
 
-    return nullptr;
+    return button;// nullptr;
 }
 
 
@@ -171,7 +183,7 @@ ToolbarButton* CabbageToolbarFactory::createButtonFromSVG (const int itemId, con
     ScopedPointer<XmlElement> svgNormal (XmlDocument::parse (svgFile));
 
     if (svgNormal == nullptr)
-        jassert (false);
+        return nullptr;//jassert (false);
 
     Drawable* drawableNormal = nullptr;
 

--- a/Source/Application/FileTab.cpp
+++ b/Source/Application/FileTab.cpp
@@ -225,20 +225,20 @@ void FileTab::setDrawableImages (DrawableButton& button, int width, int height, 
     }
     else if (type == "editGUI")
     {
-        if (iconsPath == "") // if there is no iconsPath defined, then we fallback on the previous hard-coded icon:
-        {
+        String svgFile = getSVGTextFromFile (iconsPath + "/filetab-editGUI-off.svg");
+        ScopedPointer<XmlElement> svgOff (XmlDocument::parse (svgFile));
+
+        svgFile = getSVGTextFromFile (iconsPath + "/filetab-editGUI-on.svg");
+        ScopedPointer<XmlElement> svgOn (XmlDocument::parse (svgFile));
+
+        if (iconsPath == "" || svgOn == nullptr || svgOff == nullptr) 
+        { // if there is no iconsPath defined (or the svg files are missing), then we fallback on the previous hard-coded icon:
             imageNormal.setImage (CabbageImages::drawEditGUIIcon (width, height));
             imageNormalPressed.setImage (CabbageImages::drawEditGUIIcon (width - 1, height - 1));
             button.setImages (&imageNormal, &imageNormal, &imageNormalPressed, &imageNormal, &imageNormal, nullptr, &imageNormalPressed, &imageNormalPressed);
         }
         else
         {
-            String svgFile = getSVGTextFromFile (iconsPath + "/filetab-editGUI-off.svg");
-            ScopedPointer<XmlElement> svgOff (XmlDocument::parse (svgFile));
-
-            svgFile = getSVGTextFromFile (iconsPath + "/filetab-editGUI-on.svg");
-            ScopedPointer<XmlElement> svgOn (XmlDocument::parse (svgFile));
-
             if (svgOff == nullptr || svgOn == nullptr)
                 jassert (false);
             

--- a/Source/Application/FileTab.cpp
+++ b/Source/Application/FileTab.cpp
@@ -133,10 +133,12 @@ void FileTab::paintButton (Graphics& g, bool isMouseOverButton, bool isButtonDow
     if (isEnabled() == false)
         jassert (false);
 
-    Colour baseColour (getToggleState() ? buttonColour : Colour (30, 30, 30));
+    Colour baseColour (getToggleState() ? buttonColour : buttonColour.darker (1.0f)); // Colour (30, 30, 30));
 
     if (isButtonDown || isMouseOverButton)
         baseColour = baseColour.contrasting (isButtonDown ? 0.2f : 0.1f);
+
+    overlay.overlayColour = baseColour;
 
     const bool flatOnLeft   = isConnectedOnLeft();
     const bool flatOnRight  = isConnectedOnRight();

--- a/Source/Application/FileTab.h
+++ b/Source/Application/FileTab.h
@@ -35,10 +35,13 @@ class FileTab : public TextButton
     class Overlay : public Component
     {
     public:
-        Overlay(): Component() {}
+        Overlay() : Component() {}
+
+        Colour overlayColour = Colours::black;
+
         void paint (Graphics& g)  override
         {
-            g.fillAll (Colours::black.withAlpha (.5f));
+            g.fillAll (overlayColour.withAlpha (.7f));
         }
     };
 
@@ -65,6 +68,7 @@ public:
     void drawButtonText (Graphics& g);
 	void setButtonColour(Colour colour) {
 		buttonColour = colour;
+        overlay.overlayColour = colour;
 	}
 	void setFontColour(Colour colour) {
 		fontColour = colour;

--- a/Source/Utilities/CabbageUtilities.h
+++ b/Source/Utilities/CabbageUtilities.h
@@ -174,21 +174,22 @@ public:
         g.fillPath (p);
         p.clear();
 
-        g.setColour (Colours::grey.darker(.3f)/*Colours::cornflowerblue*/);
+        g.setColour (Colours::lightgrey);//Colours::cornflowerblue);
         p.addEllipse (4, 4, width - 8, height - 8);
         const float dashLengths[] = { 3.0f, 3.0f };
         PathStrokeType (6.0, PathStrokeType::mitered).createDashedStroke (dashedP, p, dashLengths, 2);
         g.fillPath (dashedP);
         p.clear();
 
-        g.setColour (Colours::grey.darker(0.35f)/*Colours::cornflowerblue.darker()*/);
-        p.addEllipse (3, 3, width - 6, height - 6);
-        g.fillPath (p);
+        g.setColour (Colours::grey.brighter(0.3f));//Colours::cornflowerblue.darker());
+        //p.addEllipse (3, 3, width - 6, height - 6);
+        //g.fillPath (p);
+        g.drawEllipse (5, 5, width - 10, height - 10, 5);
         p.clear();
 
-		g.setColour(Colour(82, 99, 106).darker(.5f));//*Colour (30, 30, 30));
+		/*g.setColour(Colour(82, 99, 106));//Colour (30, 30, 30));
         p.addEllipse (6, 6, width - 12, height - 12);
-        g.fillPath (p);
+        g.fillPath (p);*/
         return img;
     }
 

--- a/Themes/modern-darkBG/modern-darkBG.xml
+++ b/Themes/modern-darkBG/modern-darkBG.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <PROPERTIES>
- <VALUE name="Colours_Interface - MenuBar Background" val="00000000"/>
-  <VALUE name="Colours_Interface - MenuBar Text" val="FFFFFFFF"/>
-  <VALUE name="Colours_Interface - MenuBar MouseOver Background" val="ff5c7387"/>
-  <VALUE name="Colours_Interface - PopupMenu MouseOver Background" val="ff6c8090"/>
-  <VALUE name="Colours_Interface - PopupMenu Background" val="ff474e54"/>
-  <VALUE name="Colours_Interface - PopupMenu Text" val="ffd9e4e7"/>
-  <VALUE name="Colours_Interface - PopupMenu Highlighted Text" val="ffffffff"/>
-  <VALUE name="Colours_Interface - Main Background" val="ff52636a"/>
-  <VALUE name="Colours_Interface - Status Bar" val="ff000000"/>
-  <VALUE name="Colours_Interface - Status Bar Text" val="ffffffff"/>
-  <VALUE name="Colours_Interface - Property Panel Background" val="ffa6b3b9"/>
-  <VALUE name="Colours_Interface - Property Label Background" val="ffd4d4d4"/>
-  <VALUE name="Colours_Interface - Property Label Text" val="ff000000"/>
-  <VALUE name="Colours_Interface - File Tab Bar" val="ff323e44"/>
-  <VALUE name="Colours_Interface - File Tab Button" val="ff52636a"/>
-  <VALUE name="Colours_Interface - File Tab Text" val="ffffffff"/>
-  <VALUE name="Colours_Interface - File Tab Play Button" val="ff323e44"/>
-  <VALUE name="Colours_Interface - Patcher" val="ffc8c8c8"/>
-  <VALUE name="Colours_Editor - Code Background" val="ff263238"/>
-  <VALUE name="Colours_Editor - Line Numbers Background" val="ff323e44"/>
-  <VALUE name="Colours_Editor - Line Numbers" val="e999a7ae"/>
-  <VALUE name="Colours_Editor - Selected Text Background" val="ff3f616c"/>
-  <VALUE name="Colours_Editor - Caret" val="fff39636"/>
-  <VALUE name="Colours_Editor - Identifier" val="ffcfcfcf"/>
-  <VALUE name="Colours_Editor - Strings" val="ffff7154"/>
-  <VALUE name="Colours_Editor - Keyword" val="ff81a0d4"/>
-  <VALUE name="Colours_Editor - Comment" val="ff72d20c"/>
-  <VALUE name="Colours_Editor - Numbers" val="ffe9ec64"/>
-  <VALUE name="Colours_Editor - Csd Tags" val="ffbf74c5"/>
-  <VALUE name="Colours_Editor - Scrollbars" val="ff5a626f"/>
-  <VALUE name="Colours_Console - Text" val="ff566c7b"/>
-  <VALUE name="Colours_Console - Background" val="ff16191d"/>
-  <VALUE name="Colours_Console - Outline" val="ff16191d"/>
+<VALUE name="Colours_Interface - MenuBar Background" val="ff52636a"/>
+<VALUE name="Colours_Interface - MenuBar Text" val="ffffffff"/>
+<VALUE name="Colours_Interface - MenuBar MouseOver Background" val="ff5c7387"/>
+<VALUE name="Colours_Interface - PopupMenu MouseOver Background" val="ff6c8090"/>
+<VALUE name="Colours_Interface - PopupMenu Background" val="ff474e54"/>
+<VALUE name="Colours_Interface - PopupMenu Text" val="ffd9e4e7"/>
+<VALUE name="Colours_Interface - PopupMenu Highlighted Text" val="ffffffff"/>
+<VALUE name="Colours_Interface - Main Background" val="ff52636a"/>
+<VALUE name="Colours_Interface - Status Bar" val="ff000000"/>
+<VALUE name="Colours_Interface - Status Bar Text" val="ffffffff"/>
+<VALUE name="Colours_Interface - Property Panel Background" val="ffa6b3b9"/>
+<VALUE name="Colours_Interface - Property Label Background" val="ffd4d4d4"/>
+<VALUE name="Colours_Interface - Property Label Text" val="ff000000"/>
+<VALUE name="Colours_Interface - Alart Window Background" val="ff000000"/>
+<VALUE name="Colours_Interface - File Tab Bar" val="ff323e44"/>
+<VALUE name="Colours_Interface - File Tab Button" val="ff52636a"/>
+<VALUE name="Colours_Interface - File Tab Text" val="ffffffff"/>
+<VALUE name="Colours_Interface - File Tab Play Button" val="ff323e44"/>
+<VALUE name="Colours_Interface - Patcher" val="ffc8c8c8"/>
+<VALUE name="Colours_Editor - Code Background" val="ff263238"/>
+<VALUE name="Colours_Editor - Line Numbers Background" val="ff323e44"/>
+<VALUE name="Colours_Editor - Line Numbers" val="e999a7ae"/>
+<VALUE name="Colours_Editor - Selected Text Background" val="ff3f616c"/>
+<VALUE name="Colours_Editor - Caret" val="fff39636"/>
+<VALUE name="Colours_Editor - Identifier" val="ffcfcfcf"/>
+<VALUE name="Colours_Editor - Strings" val="ff8ac3f3"/>
+<VALUE name="Colours_Editor - Keyword" val="ffee6f6f"/>
+<VALUE name="Colours_Editor - Comment" val="ff72d20c"/>
+<VALUE name="Colours_Editor - Numbers" val="ffe9ec64"/>
+<VALUE name="Colours_Editor - Csd Tags" val="ffbf74c5"/>
+<VALUE name="Colours_Editor - Scrollbars" val="ff5a626f"/>
+<VALUE name="Colours_Console - Text" val="ff566c7b"/>
+<VALUE name="Colours_Console - Background" val="ff16191d"/>
+<VALUE name="Colours_Console - Outline" val="ff16191d"/>
 </PROPERTIES>


### PR DESCRIPTION
- Fixed a bug when you click on the Show Editor button with a .csd file that has no cabbage section (i.e. a plain csound file).

- Made Cabbage fallback on its original hard-coded or bitmap icons if there are no svg in your custom icons folder.

- Fixed modern-darkBG.xml theme colours.