### PR TITLE
Added flat style for rslider and encoder widgets

### DIFF
--- a/Source/LookAndFeel/FlatButtonLookAndFeel.cpp
+++ b/Source/LookAndFeel/FlatButtonLookAndFeel.cpp
@@ -374,3 +374,80 @@ void FlatButtonLookAndFeel::drawTwoValueThumb (Graphics& g, float x, float y, fl
     g.setColour (Colours::black.withAlpha (0.5f * colour.getFloatAlpha()));
     g.strokePath (p, PathStrokeType (outlineThickness));
 }
+
+//==========================================================================================================================================
+void FlatButtonLookAndFeel::drawRotarySlider (Graphics& g, int x, int y, int width, int height, float sliderPos,
+    const float rotaryStartAngle, const float rotaryEndAngle, Slider& slider)
+{
+    const float radius = jmin (width / 2, height / 2) - 2.0f;
+    const float diameter = radius * 2.f;
+    const float centreX = x + width * 0.5f;
+    const float centreY = y + height * 0.5f;
+    const float rx = centreX - radius;
+    const float ry = centreY - radius;
+    const float rw = radius * 2.0f;
+    const float angle = rotaryStartAngle + sliderPos * (rotaryEndAngle - rotaryStartAngle);
+    const bool isMouseOver = slider.isMouseOverOrDragging() && slider.isEnabled();
+    Image image;
+    
+    const float innerRadiusProportion = slider.getProperties().getWithDefault ("trackerinnerradius", .7);
+    const float outerRadiusProportion = slider.getProperties().getWithDefault ("trackerouterradius", 1);
+    const float thumbThickness = (outerRadiusProportion - innerRadiusProportion) / 4.0f / 2.0f;
+
+    slider.setSliderStyle (Slider::RotaryVerticalDrag);
+
+    //tracker
+    g.setColour (slider.findColour (Slider::trackColourId).contrasting (isMouseOver ? 0.1f : 0.0f));
+        
+    const float thickness = slider.getProperties().getWithDefault ("trackerthickness", 1);
+    {
+        Path filledArc;
+        filledArc.addPieSegment (rx, ry, rw, rw, rotaryStartAngle, angle, innerRadiusProportion);
+        filledArc.applyTransform(AffineTransform::identity.scaled(outerRadiusProportion, outerRadiusProportion, width / 2.f, height / 2.f));
+        g.fillPath (filledArc);
+    }
+
+    //outinecolour
+    Colour outlineColour = slider.findColour (Slider::rotarySliderOutlineColourId);
+    g.setColour (outlineColour);
+
+    Path outlineArc;
+    outlineArc.addPieSegment (rx, ry, rw, rw, rotaryStartAngle, rotaryEndAngle, innerRadiusProportion);
+    outlineArc.applyTransform(AffineTransform::identity.scaled(outerRadiusProportion, outerRadiusProportion, width / 2.f, height / 2.f));
+    outlineArc.closeSubPath();
+
+    g.strokePath (outlineArc, PathStrokeType (slider.isEnabled() ? (isMouseOver ? 2.0f : 1.2f) : 0.3f));
+        
+    Path newPolygon;
+    Point<float> centre (centreX, centreY);
+
+    if (diameter >= 25)   //If diameter is >= 40 then polygon has 12 steps
+    {
+        newPolygon.addPolygon (centre, 24.f, radius * innerRadiusProportion, 0.f);
+        newPolygon.applyTransform (AffineTransform::rotation (angle, centreX, centreY));
+    }
+    else //Else just use a circle. This is clearer than a polygon when very small.
+        newPolygon.addEllipse (-radius * .2, -radius * .2, radius * .3f, radius * .3f);
+
+    g.setColour (slider.findColour (Slider::thumbColourId).withAlpha (isMouseOver ? slider.findColour (Slider::thumbColourId).getFloatAlpha() : slider.findColour (Slider::thumbColourId).getFloatAlpha() * 0.9f));
+
+    Colour thumbColour = slider.findColour (Slider::thumbColourId).withAlpha (isMouseOver ? slider.findColour (Slider::thumbColourId).getFloatAlpha() : slider.findColour (Slider::thumbColourId).getFloatAlpha() * 0.9f);
+
+    g.setColour (thumbColour);
+    g.fillPath (newPolygon);
+
+    // Draw the thumb segment:
+    Path p;
+    g.setColour (slider.findColour (Slider::trackColourId).withAlpha (1.0f).contrasting (isMouseOver ? 0.1f : 0.0f));
+    float thumbLength = radius * innerRadiusProportion * 0.95f;
+    p.addLineSegment (Line<float> (0.0f, -thumbLength * 0.5f, 0.0f, -thumbLength * 0.9f), rw * thumbThickness);
+    PathStrokeType (rw * thumbThickness, juce::PathStrokeType::JointStyle::curved, juce::PathStrokeType::EndCapStyle::rounded).createStrokedPath (p, p);
+    g.fillPath (p, AffineTransform::rotation (angle).translated (centreX, centreY));
+
+    // Draw the slider arc background:
+    g.setColour (outlineColour);
+    Path bgArc;
+    bgArc.addPieSegment (rx, ry, rw, rw, angle/* + 0.07f * (rotaryEndAngle - rotaryStartAngle)*/, rotaryEndAngle, innerRadiusProportion);
+    bgArc.applyTransform(AffineTransform::identity.scaled(outerRadiusProportion, outerRadiusProportion, width / 2.f, height / 2.f));
+    g.fillPath (bgArc);
+}

--- a/Source/LookAndFeel/FlatButtonLookAndFeel.h
+++ b/Source/LookAndFeel/FlatButtonLookAndFeel.h
@@ -18,7 +18,7 @@ public:
         int w, int h, int titleSpaceX, int titleSpaceW,
         const Image* icon, bool drawTitleTextOnLeft) override;
 
-    // H/V SLIDERS L&F:
+    // H/V/ROTARY SLIDERS L&F:
     void drawLinearSliderBackground (Graphics& g, int x, int y, int width, int height, float sliderPos, float minSliderPos, float maxSliderPos, const Slider::SliderStyle style, Slider& slider) override;
 
     void drawLinearSliderThumb (Graphics& g, int x, int y, int width, int height, float sliderPos, float minSliderPos, float maxSliderPos, const Slider::SliderStyle style, Slider& slider) override;
@@ -26,5 +26,7 @@ public:
     void drawThumb (Graphics& g, const float x, const float y, const float w, const float h, const Colour& colour, const float outlineThickness);
 
     void drawTwoValueThumb (Graphics& g, float x, float y, float diameter, const Colour& colour, float outlineThickness, int direction);
-    // ----------------
+
+    void drawRotarySlider (Graphics& g, int x, int y, int width, int height, float sliderPos, const float rotaryStartAngle, const float rotaryEndAngle, Slider& slider);
+    // -----------------------
 };

--- a/Source/Widgets/CabbageEncoder.cpp
+++ b/Source/Widgets/CabbageEncoder.cpp
@@ -46,6 +46,8 @@ CabbageEncoder::CabbageEncoder (ValueTree wData, CabbagePluginEditor* _owner)
     valueLabel.setColour (Label::backgroundColourId, Colours::black);
     valueLabel.setColour (Label::outlineColourId, Colours::whitesmoke);
 
+    if (CabbageWidgetData::getStringProp (wData, CabbageIdentifierIds::style) == "flat")
+        flatStyle = true;
 }
 
 void CabbageEncoder::createPopupBubble()
@@ -186,7 +188,7 @@ void CabbageEncoder::paint (Graphics& g)
 
         if (diameter >= 25)   //If diameter is >= 40 then polygon has 12 steps
         {
-            newPolygon.addPolygon (centre, 12.f, radius, 0.f);
+            newPolygon.addPolygon (centre, 24.f, radius, 0.f);
             newPolygon.applyTransform (AffineTransform::rotation (angle,
                                                                   centreX, centreY));
         }
@@ -196,11 +198,16 @@ void CabbageEncoder::paint (Graphics& g)
         g.setColour (Colour::fromString (colour));
 
         Colour thumbColour = Colour::fromString (colour).withAlpha (isMouseOver ? 1.0f : 0.9f);
-        ColourGradient cg = ColourGradient (Colours::white, 0, 0, thumbColour, diameter * 0.6, diameter * 0.4, false);
-        //if(slider.findColour (Slider::thumbColourId)!=Colour(0.f,0.f,0.f,0.f))
-        g.setGradientFill (cg);
-        g.fillPath (newPolygon);
+        if (!flatStyle)
+        {
+            ColourGradient cg = ColourGradient (Colours::white, 0, 0, thumbColour, diameter * 0.6, diameter * 0.4, false);
+            //if(slider.findColour (Slider::thumbColourId)!=Colour(0.f,0.f,0.f,0.f))
+            g.setGradientFill (cg);
+        }
+        else
+            g.setColour (thumbColour);
 
+        g.fillPath (newPolygon);
 
         g.setColour (Colour::fromString (trackercolour).withAlpha (isMouseOver ? 1.0f : 0.9f));
 

--- a/Source/Widgets/CabbageEncoder.h
+++ b/Source/Widgets/CabbageEncoder.h
@@ -50,6 +50,7 @@ class CabbageEncoder : public Component, public ValueTree::Listener, public Cabb
     int decimalPlaces = 1;
     String outlinecolour, colour, trackercolour, text, textcolour, popupText;
     BubbleMessageComponent popupBubble;
+    bool flatStyle = false;
 
 public:
 


### PR DESCRIPTION
- Added a new look for rotary sliders to make them look better with a flat style (when you use the style("flat") identifier for rsliders).
- If you use style("flat") for the encoder widget, the light colour gradient of the slider will not be used anymore.
- Increased the number of segments to make rotary slider and encoder look better.