### PR TITLE
Build method without Projucer

### DIFF
--- a/Builds/LinuxMakefile/buildCabbage
+++ b/Builds/LinuxMakefile/buildCabbage
@@ -12,21 +12,34 @@ echo "located in /user/local/lib "
 echo "It is also assumes that the VST SDK is located in ~/SDKs/"
 echo ""
 
+cabbage_dir="$(pwd)/../.."
+juce_dir="$cabbage_dir/../JUCE"
+
+setup_juce_project() {
+  local proj="$1"
+  local makefilename="$2"
+
+  if [ ! -f "project-caches/$proj.tar.gz" ]; then
+    "$juce_dir/extras/Projucer/Builds/LinuxMakefile/build/Projucer" --resave "$cabbage_dir/$proj.jucer"
+    mv -f Makefile "$makefilename"
+  else
+    echo "$(tput bold)Using project cache for $proj…$(tput sgr0)"
+    tar -C "$cabbage_dir" -x -z -f "$(pwd)/project-caches/$proj.tar.gz"
+  fi
+}
+
 if [ "$1" == "debug" ]; then
   echo "Hello debug"
-  ../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbageIDE.jucer
-  mv Makefile MakeCabbageIDE
+  setup_juce_project CabbageIDE MakeCabbageIDE
   make -f MakeCabbageIDE clean
   make -f MakeCabbageIDE -j6 
   cp ./build/Cabbage /usr/bin/Cabbage
 
-  ../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbagePlugin.jucer
-  mv Makefile MakePluginEffect
+  setup_juce_project CabbagePlugin MakePluginEffect
   make -f MakePluginEffect clean 
   make -f MakePluginEffect -j6
 
-  ../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbagePluginSynth.jucer
-  mv Makefile MakePluginSynth
+  setup_juce_project CabbagePluginSynth MakePluginSynth
   make -f MakePluginSynth clean
   make -f MakePluginSynth -j6 
 else
@@ -34,32 +47,28 @@ else
 
   mkdir -p ./install/bin ./install/images ./install/desktop
 
-  ../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbageIDE.jucer
-  mv Makefile MakeCabbageIDE
+  setup_juce_project CabbageIDE MakeCabbageIDE
   echo "$(tput bold)Building CabbageIDE…$(tput sgr0)"
 
   make -f MakeCabbageIDE clean CONFIG=Release
   make -f MakeCabbageIDE -j6 CONFIG=Release
   cp ./build/Cabbage ./install/bin/Cabbage
 
-  ../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbagePlugin.jucer
-  mv Makefile MakePluginEffect
+  setup_juce_project CabbagePlugin MakePluginEffect
   echo "$(tput bold)Building PluginEffect…$(tput sgr0)"
 
   make -f MakePluginEffect clean CONFIG=Release
   make -f MakePluginEffect -j6 CONFIG=Release
   cp ./build/CabbagePlugin.so ./install/bin/CabbagePluginEffect.so
 
-  ../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbagePluginSynth.jucer
-  mv Makefile MakePluginSynth
+  setup_juce_project CabbagePluginSynth MakePluginSynth
   echo "$(tput bold)Building PluginSynth…$(tput sgr0)"
 
   make -f MakePluginSynth clean CONFIG=Release
   make -f MakePluginSynth -j6 CONFIG=Release
   cp ./build/CabbagePlugin.so ./install/bin/CabbagePluginSynth.so
 
-  ../../../JUCE/extras/Projucer/Builds/LinuxMakefile/build/Projucer --resave ../../CabbageLite.jucer
-  mv Makefile MakeCabbageLite
+  setup_juce_project CabbageLite MakeCabbageLite
   echo "$(tput bold)Building CabbageLite…$(tput sgr0)"
 
   make -f MakeCabbageLite clean CONFIG=Release

--- a/Builds/LinuxMakefile/makeProjectCaches
+++ b/Builds/LinuxMakefile/makeProjectCaches
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+echo "==========================================="
+echo "======= Caching Script for Cabbage ========"
+echo "==========================================="
+
+echo "This generates archives of sources and build files created by Projucer for each project."
+echo "The archives are located under the subdirectory: project-caches"
+echo "When they are present, this allows to build Cabbage in a situation where Projucer cannot run."
+echo "Projucer cannot run without X11, which can make it difficult to build Linux packages on headless machines."
+
+cabbage_dir="$(pwd)/../.."
+juce_dir="${cabbage_dir}/../JUCE"
+
+make_project_cache() {
+  local proj="$1"
+  local makefilename="$2"
+
+  echo "$(tput bold)Caching $proj…$(tput sgr0)"
+
+  mkdir -p project-caches
+  "$juce_dir/extras/Projucer/Builds/LinuxMakefile/build/Projucer" --resave "$cabbage_dir/$proj.jucer"
+  mv -f Makefile "$makefilename"
+
+  echo "$(tput bold)Saving cache results $proj…$(tput sgr0)"
+
+  tar -C "$cabbage_dir" -c -z -f "$(pwd)/project-caches/$proj.tar.gz" \
+    JuceLibraryCode \
+    "Builds/LinuxMakefile/$makefilename"
+}
+
+make_project_cache CabbageIDE MakeCabbageIDE
+make_project_cache CabbageLite MakeCabbageLite
+make_project_cache CabbagePlugin MakePluginEffect
+make_project_cache CabbagePluginMIDIEffect MakePluginMIDIEffect
+make_project_cache CabbagePluginSynth MakePluginSynth


### PR DESCRIPTION
I provide a method to build Cabbage in a scenario where Projucer is not available.
The goal is to provide deb packages for the Linux distribution LibraZiK.

The problem: in headless chroot situations, Projucer cannot be run; it requires X11.
The proposed solution: to run Projucer on a regular machine, save the result in an archive. Then, the builder can just unpack this, skipping the Projucer step.

I changed the build script such that: if it finds the cache, it will use it, otherwise it will proceed the usual way.
The script `makeProjectCaches` serves in order to construct the cache archives for every project.