### PR TITLE
update header paths on Linux

### DIFF
--- a/Builds/LinuxMakefile/buildCabbage
+++ b/Builds/LinuxMakefile/buildCabbage
@@ -74,7 +74,7 @@ cp ./../../Images/cabbage.png ./install/images/cabbagelite.png
 cp -rf ../../Examples ./install/
 cp -rf ../../Themes ./install/
 
-g++ ../../Source/testCsoundFile.cpp -o testCsoundFile -I"/usr/local/include/csound" -lcsound64
+g++ ../../Source/testCsoundFile.cpp -o testCsoundFile -I"/usr/local/include/csound" -I"/usr/include/csound" -lcsound64
 # cp testCsoundFile ./install/bin/testCsoundFile
 #cp -rf ../../Docs/_book CabbageBuild/Docs
 

--- a/CabbageLite.jucer
+++ b/CabbageLite.jucer
@@ -233,9 +233,10 @@
                 externalLibraries="csound64&#10;sndfile">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="CabbageLite"
-                       headerPath="&quot;/usr/local/include/csound&quot;" libraryPath="&quot;/usr/local/lib&quot;"/>
+                       headerPath="&quot;/usr/local/include/csound&quot;&#10;&quot;/usr/include/csound&quot;"
+                       libraryPath="&quot;/usr/local/lib&quot;"/>
         <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="CabbageLite"
-                       libraryPath="&quot;/usr/local/lib&quot;" headerPath="&quot;/usr/local/include/csound&quot;"/>
+                       libraryPath="&quot;/usr/local/lib&quot;" headerPath="&quot;/usr/local/include/csound&quot;&#10;&quot;/usr/include/csound&quot;"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_core" path="../JUCE/modules"/>

--- a/CabbagePluginMIDIEffect.jucer
+++ b/CabbagePluginMIDIEffect.jucer
@@ -200,10 +200,10 @@
                 extraLinkerFlags="-Wall">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="CabbagePlugin"
-                       headerPath="&quot;/usr/local/include/csound&quot;&#10;&quot;/usr/include/csound&quot;~/SDKs/VST_SDK/VST3_SDK&quot;"
+                       headerPath="&quot;/usr/local/include/csound&quot;&#10;&quot;/usr/include/csound&quot;&#10;&quot;~/SDKs/VST_SDK/VST3_SDK&quot;"
                        libraryPath="&quot;/usr/local/lib&quot;" defines="Cabbage_Plugin_Synth=1"/>
         <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="CabbagePlugin"
-                       headerPath="&quot;/usr/local/include/csound&quot;&#10;&quot;/usr/include/csound&quot;~/SDKs/VST_SDK/VST3_SDK&quot;"
+                       headerPath="&quot;/usr/local/include/csound&quot;&#10;&quot;/usr/include/csound&quot;&#10;&quot;~/SDKs/VST_SDK/VST3_SDK&quot;"
                        libraryPath="&quot;/usr/local/lib&quot;" defines="Cabbage_Plugin_Synth=1"/>
       </CONFIGURATIONS>
       <MODULEPATHS>

--- a/CabbagePluginUnity.jucer
+++ b/CabbagePluginUnity.jucer
@@ -205,10 +205,10 @@
                 extraLinkerFlags="-Wall">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="CabbagePlugin"
-                       headerPath="&quot;/usr/local/include/csound&quot;&#10;&quot;~/SDKs/VST_SDK/VST3_SDK&quot;"
+                       headerPath="&quot;/usr/local/include/csound&quot;&#10;&quot;/usr/include/csound&quot;&#10;&quot;~/SDKs/VST_SDK/VST3_SDK&quot;"
                        libraryPath="&quot;/usr/local/lib&quot;" defines=""/>
         <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="CabbagePlugin"
-                       headerPath="&quot;/usr/local/include/csound&quot;&#10;&quot;~/SDKs/VST_SDK/VST3_SDK&quot;"
+                       headerPath="&quot;/usr/local/include/csound&quot;&#10;&quot;/usr/local/include/csound&quot;&#10;&quot;~/SDKs/VST_SDK/VST3_SDK&quot;"
                        libraryPath="&quot;/usr/local/lib&quot;" defines=""/>
       </CONFIGURATIONS>
       <MODULEPATHS>


### PR DESCRIPTION
This adds the path `/usr/include/csound` everywhere missing, allowing a build from csound based in the `/usr` path.