### PR TITLE
fix some compiler warnings

### DIFF
--- a/Source/Application/CabbageMainComponent.h
+++ b/Source/Application/CabbageMainComponent.h
@@ -222,7 +222,7 @@ public:
 		CabbageMainComponent* owner;
 	public:
 		FilterGraphDocumentWindow(String caption, Colour backgroundColour, CabbageMainComponent* owner)
-			: DocumentWindow(caption, backgroundColour, DocumentWindow::TitleBarButtons::allButtons), owner(owner), colour(backgroundColour)
+			: DocumentWindow(caption, backgroundColour, DocumentWindow::TitleBarButtons::allButtons), colour(backgroundColour), owner(owner)
 		{
 			setSize(600, 600);
 			setName(caption);
@@ -244,8 +244,8 @@ public:
     public:
         VerticalResizerBar (ValueTree valueTree, CabbageMainComponent* parent)
         :   Component ("ResizerBar"),
-        valueTree (valueTree),
-        owner (parent)
+        valueTree (valueTree)
+        // owner (parent)
         {
             
         }
@@ -259,9 +259,9 @@ public:
         
     private:
         ValueTree valueTree;
-        int startingYPos;
+        // int startingYPos;
         int currentYPos = 550;
-        CabbageMainComponent* owner;
+        // CabbageMainComponent* owner;
     };
     
     VerticalResizerBar resizerBar;
@@ -325,11 +325,11 @@ private Button::Listener
 public:
     FindPanel (String searchString, bool isCaseSensitive, bool withReplace)
         : caseButton ("Case-sensitive"),
+          showReplaceControls (withReplace),
           findPrev ("<"),
           findNext (">"),
           replace ("Replace"),
-          replaceAll ("Replace All"),
-          showReplaceControls (withReplace)
+          replaceAll ("Replace All")
     {
         //find components...
         setSize (260, withReplace == false ? 90 : 180);

--- a/Source/Audio/Filters/FilterGraph.h
+++ b/Source/Audio/Filters/FilterGraph.h
@@ -312,16 +312,16 @@ public:
 		AudioProcessorGraph::NodeAndChannel outputL = { (AudioProcessorGraph::NodeID) InternalNodes::AudioOutput, 0 };
 		AudioProcessorGraph::NodeAndChannel outputR = { (AudioProcessorGraph::NodeID) InternalNodes::AudioOutput, 1 };
 
-		bool connectInput1 = graph.addConnection({ inputL, nodeL });
-		bool connectInput2 = graph.addConnection({ inputR, nodeR });
+		/* bool connectInput1 = */ graph.addConnection({ inputL, nodeL });
+		/* bool connectInput2 = */ graph.addConnection({ inputR, nodeR });
 
-		bool connection1 = graph.addConnection({ nodeL, outputL });
-		bool connection2 = graph.addConnection({ nodeR, outputR });
+		/* bool connection1 = */ graph.addConnection({ nodeL, outputL });
+		/* bool connection2 = */ graph.addConnection({ nodeR, outputR });
 		
 		AudioProcessorGraph::NodeAndChannel midiIn = { (AudioProcessorGraph::NodeID) InternalNodes::MIDIInput, AudioProcessorGraph::midiChannelIndex };
 		AudioProcessorGraph::NodeAndChannel midiOut = { (AudioProcessorGraph::NodeID) nodeId, AudioProcessorGraph::midiChannelIndex };
 
-		bool connection3 = graph.addConnection({ midiIn, midiOut });
+		/* bool connection3 = */ graph.addConnection({ midiIn, midiOut });
 
 	}
 	//======================================================================================

--- a/Source/Audio/Plugins/CabbagePluginEditor.h
+++ b/Source/Audio/Plugins/CabbagePluginEditor.h
@@ -170,7 +170,7 @@ public:
     void addPlantToPopupPlantsArray (ValueTree wData, Component* plant);
     //=============================================================================
     void buttonClicked (Button* button) override;
-    void buttonStateChanged (Button* button);
+    void buttonStateChanged (Button* button) override;
     void toggleButtonState (Button* button, bool state);
     void comboBoxChanged (ComboBox* combo) override;
     void sliderValueChanged (Slider* slider) override;
@@ -225,7 +225,7 @@ public:
             CabbageWidgetData::setNumProp(plantWidgetData, CabbageIdentifierIds::visible, 0);
         }
 
-        void paint (Graphics& g){               g.fillAll (colour);         }
+        void paint (Graphics& g) override {               g.fillAll (colour);         }
         void setWidgetData(ValueTree wData){    plantWidgetData = wData;    }
     };
 

--- a/Source/Audio/Plugins/CabbagePluginProcessor.h
+++ b/Source/Audio/Plugins/CabbagePluginProcessor.h
@@ -71,8 +71,8 @@ public:
     ~CabbagePluginProcessor();
 
     ValueTree cabbageWidgets;
-    void getChannelDataFromCsound();
-    void triggerCsoundEvents();
+    void getChannelDataFromCsound() override;
+    void triggerCsoundEvents() override;
     void setWidthHeight();
     bool addImportFiles (StringArray& lineFromCsd);
     void parseCsdFile (StringArray& linesFromCsd);
@@ -88,7 +88,7 @@ public:
     void setPluginName (String name) {    pluginName = name;  }
     String getPluginName() { return pluginName;  }
     void expandMacroText (String &line, ValueTree wData);
-	void prepareToPlay(double sampleRate, int samplesPerBlock);
+	void prepareToPlay(double sampleRate, int samplesPerBlock) override;
 	void setCabbageParameter(String channel, float value);
     CabbageAudioParameter* getParameterForXYPad (String name);
     //==============================================================================
@@ -143,7 +143,7 @@ class CabbageAudioParameter : public AudioParameterFloat
 
 public:
 	CabbageAudioParameter(CabbagePluginProcessor* owner, ValueTree wData, Csound& csound, String channel, String name, float minValue, float maxValue, float def, float incr, float skew)
-		: AudioParameterFloat(name, channel, NormalisableRange<float>(minValue, maxValue, incr, skew), def), currentValue(def), widgetName(name), channel(channel), owner(owner)
+		: AudioParameterFloat(name, channel, NormalisableRange<float>(minValue, maxValue, incr, skew), def), channel(channel), widgetName(name), currentValue(def), owner(owner)
 	{
 		// widgetType = CabbageWidgetData::getStringProp (widgetData, CabbageIdentifierIds::type);
         if(name.contains("combobox"))

--- a/Source/Audio/Plugins/CsoundPluginProcessor.cpp
+++ b/Source/Audio/Plugins/CsoundPluginProcessor.cpp
@@ -352,7 +352,6 @@ void CsoundPluginProcessor::addMacros (String csdText)
 void CsoundPluginProcessor::createMatrixEventSequencer(int rows, int cols, String channel)
 {
     MatrixEventSequencer* matrix = new MatrixEventSequencer(channel);
-    (channel);
 
     for (int i = 0 ; i < cols ; i++)
     {

--- a/Source/Audio/Plugins/CsoundPluginProcessor.h
+++ b/Source/Audio/Plugins/CsoundPluginProcessor.h
@@ -186,12 +186,12 @@ public:
         String caption;
 
         SignalDisplay (String _caption, int _id, float _scale, int _min, int _max, int _size):
-            caption (_caption),
-            windid (_id),
             yScale (_scale),
+            windid (_id),
             min (_min),
             max (_max),
-            size (_size)
+            size (_size),
+            caption (_caption)
         {}
 
         ~SignalDisplay()

--- a/Source/Audio/Plugins/GenericCabbagePluginProcessor.h
+++ b/Source/Audio/Plugins/GenericCabbagePluginProcessor.h
@@ -26,7 +26,7 @@ public:
 
     OwnedArray<AudioParameterFloat> parameters;
 
-    void sendChannelDataToCsound();
+    void sendChannelDataToCsound() override;
     void setPluginName (String name) {    pluginName = name;  }
     String getPluginName() { return pluginName;  }
 

--- a/Source/Cabbage.h
+++ b/Source/Cabbage.h
@@ -50,7 +50,7 @@ public:
 
     void timerCallback();
     void initialiseBasics();
-    void shutdown();
+    void shutdown() override;
     bool isRunningCommandLine = false;
     void initialise (const String& commandLine) override;
     void systemRequestedQuit() override

--- a/Source/CabbageCommonHeaders.h
+++ b/Source/CabbageCommonHeaders.h
@@ -20,9 +20,11 @@
 #ifndef CABBAGECOMMONHEADERS_H_INCLUDED
 #define CABBAGECOMMONHEADERS_H_INCLUDED
 
+#ifdef _MSC_VER
 #pragma warning(disable: 4244)
 #pragma warning(disable: 4100)
 #pragma warning(disable: 4305)
+#endif
 
 #define CABBAGE_VERSION "Cabbage(64bit) v2.1.06beta"
 #include "./Settings/CabbageSettings.h"

--- a/Source/CodeEditor/CabbageCodeEditor.h
+++ b/Source/CodeEditor/CabbageCodeEditor.h
@@ -105,10 +105,10 @@ public:
     public:
         AddCodeToGUIEditorComponent (CabbageCodeEditorComponent* _owner, String caption, Colour backgroundColour)
             : DocumentWindow (caption, Colour (100, 100, 100), DocumentWindow::TitleBarButtons::allButtons),
-              editor ("editor"),
-              colour (backgroundColour),
               owner (_owner),
-              cabbageLoookAndFeel()
+              colour (backgroundColour),
+              cabbageLoookAndFeel(),
+              editor ("editor")
         {
 
             setName (caption);
@@ -120,7 +120,7 @@ public:
             editor.addListener (this);
         }
 
-        void textEditorReturnKeyPressed (TextEditor&);
+        void textEditorReturnKeyPressed (TextEditor&) override;
 
         void closeButtonPressed() override
         {
@@ -192,7 +192,7 @@ public:
     //void undo() {    this->undo();               }
     //void redo() {    this->redo();               }
     //=========================================================
-    void timerCallback();
+    void timerCallback() override;
     ValueTree breakpointData;
     var findValueForCsoundVariable (String varName);
     bool debugModeEnabled = false;

--- a/Source/CodeEditor/CabbageOutputConsole.h
+++ b/Source/CodeEditor/CabbageOutputConsole.h
@@ -107,7 +107,7 @@ public:
         textEditor->setText ("");
     }
 
-    void resized()
+    void resized() override
     {
         Rectangle<int> area (getLocalBounds());
         textEditor->setBounds (area.reduced (2).withY (0));

--- a/Source/GUIEditor/CabbagePropertiesPanel.h
+++ b/Source/GUIEditor/CabbagePropertiesPanel.h
@@ -44,14 +44,14 @@ public:
     void getAmpRangeForTable (String identifier, var value);
     void getScrubberPositionForTable (String identifier, var value);
     void setPropertyByName (String name, var value);
-    void textPropertyComponentChanged (TextPropertyComponent* comp);
+    void textPropertyComponentChanged (TextPropertyComponent* comp) override;
     void changeListenerCallback (juce::ChangeBroadcaster* source) override;
     void updateProperties (ValueTree widgetData);
-    void valueChanged (Value& value);
-    void filenameComponentChanged (FilenameComponent* fileComponent);
+    void valueChanged (Value& value) override;
+    void filenameComponentChanged (FilenameComponent* fileComponent) override;
     void saveOpenessState();
 
-	void buttonClicked(Button *);
+	void buttonClicked(Button *) override;
     Array<PropertyComponent*> createPositionEditors (ValueTree valueTree);
     Array<PropertyComponent*> createTextEditors (ValueTree valueTree);
     Array<PropertyComponent*> createNumberEditors (ValueTree valueTree);

--- a/Source/GUIEditor/ComponentLayoutEditor.h
+++ b/Source/GUIEditor/ComponentLayoutEditor.h
@@ -45,22 +45,22 @@ public:
     ~ComponentLayoutEditor ();
 
     ValueTree widgetData;
-    void resized ();
+    void resized () override;
     void paint (Graphics& g)  override;
     void setTargetComponent (Component* target);
     void bindWithTarget ();
     void updateFrames ();
-    void enablementChanged ();
-    void mouseUp (const MouseEvent& e);
-    void mouseDrag (const MouseEvent& e);
-    void mouseDown (const MouseEvent& e);
+    void enablementChanged () override;
+    void mouseUp (const MouseEvent& e) override;
+    void mouseDrag (const MouseEvent& e) override;
+    void mouseDown (const MouseEvent& e) override;
     const Component* getTarget();
-    void findLassoItemsInArea (Array <ComponentOverlay*>& results, const juce::Rectangle<int>& area);
+    void findLassoItemsInArea (Array <ComponentOverlay*>& results, const juce::Rectangle<int>& area) override;
     void updateCodeEditor();
     void updateSelectedComponentBounds();
     void setComponentBoundsProperties (Component* child, Rectangle<int> bounds);
 
-    SelectedItemSet <ComponentOverlay*>& getLassoSelection();
+    SelectedItemSet <ComponentOverlay*>& getLassoSelection() override;
     LassoComponent <ComponentOverlay*> lassoComp;
     SelectedComponents selectedComponents;
     Point<int> currentMouseCoors;

--- a/Source/GUIEditor/ComponentOverlay.h
+++ b/Source/GUIEditor/ComponentOverlay.h
@@ -24,8 +24,8 @@ class ComponentOverlay   :   public Component, public KeyListener
 public:
     ComponentOverlay (Component* targetChild, ComponentLayoutEditor* layoutEditor);
     ~ComponentOverlay ();
-    void resized ();
-    void paint (Graphics& g);
+    void resized () override;
+    void paint (Graphics& g) override;
     const Component* getTargetChild ();
     void updateFromTarget ();
     void applyToTarget ();
@@ -33,13 +33,13 @@ public:
     virtual void userStartedChangingBounds () {};
     virtual void userStoppedChangingBounds () {};
     bool boundsChangedSinceStart ();
-    bool keyPressed (const KeyPress& key, Component* originatingComponent);
+    bool keyPressed (const KeyPress& key, Component* originatingComponent) override;
 
-    void mouseEnter (const MouseEvent& e);
-    void mouseExit (const MouseEvent& e);
-    void mouseDown (const MouseEvent& e);
-    void mouseUp (const MouseEvent& e);
-    void mouseDrag (const MouseEvent& e);
+    void mouseEnter (const MouseEvent& e) override;
+    void mouseExit (const MouseEvent& e) override;
+    void mouseDown (const MouseEvent& e) override;
+    void mouseUp (const MouseEvent& e) override;
+    void mouseDrag (const MouseEvent& e) override;
 
     void setInterest (String isInteresting)
     {

--- a/Source/LookAndFeel/CabbageLookAndFeel2.h
+++ b/Source/LookAndFeel/CabbageLookAndFeel2.h
@@ -24,7 +24,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
 #include "../JuceLibraryCode/JuceHeader.h"
 #include "../CabbageCommonHeaders.h"
 
-static std::unique_ptr<Drawable> createDrawableFromSVG (const char* data)
+inline std::unique_ptr<Drawable> createDrawableFromSVG (const char* data)
 {
     auto xml = parseXML (data);
     jassert (xml != nullptr);
@@ -106,7 +106,7 @@ public:
                                              int thumbStartPosition,
                                              int thumbSize,
                                              bool isMouseOver,
-                                             bool isMouseDown);
+                                             bool isMouseDown) override;
 
     void setDefaultFont(File fontFile);
 //    Font getTextButtonFont (TextButton&, int buttonHeight) override;

--- a/Source/Settings/CabbageSettingsWindow.h
+++ b/Source/Settings/CabbageSettingsWindow.h
@@ -56,15 +56,15 @@ public:
     void changeListenerCallback (ChangeBroadcaster* source) override;
     void addColourProperties();
     void addMiscProperties();
-    void resized();
-    void buttonClicked (Button* button);
+    void resized() override;
+    void buttonClicked (Button* button) override;
     void paint (Graphics& g)  override;
-    void valueChanged (Value& value);
+    void valueChanged (Value& value) override;
     void updateColourScheme();
     void mouseEnter (const MouseEvent& e) override;
     void selectPanel (String button);
-    void filenameComponentChanged (FilenameComponent*);
-    void textPropertyComponentChanged (TextPropertyComponent* comp);
+    void filenameComponentChanged (FilenameComponent*) override;
+    void textPropertyComponentChanged (TextPropertyComponent* comp) override;
     void loadRepoCode (String codeSnippetName);
 
     class RepoListBox   :   public Component, ListBoxModel
@@ -85,7 +85,7 @@ public:
         void resized() override {};
         int getNumRows() override { return items.size();};
         void setDefaultItem();
-        void listBoxItemClicked (int row, const MouseEvent&) ;
+        void listBoxItemClicked (int row, const MouseEvent&) override;
         void paintListBoxItem (int rowNumber, Graphics& g,
                                int width, int height, bool rowIsSelected) override;
         void selectedRowsChanged (int /*lastRowselected*/) override {};

--- a/Source/StandaloneLite/StandaloneFilterWindow.h
+++ b/Source/StandaloneLite/StandaloneFilterWindow.h
@@ -331,7 +331,7 @@ public:
     }
 
     //==============================================================================
-    void timerCallback()
+    void timerCallback() override
     {
         int64 modTime = csdFile.getLastModificationTime().toMilliseconds();
 

--- a/Source/Utilities/CabbageColourProperty.h
+++ b/Source/Utilities/CabbageColourProperty.h
@@ -107,7 +107,7 @@ public :
     ColourPropertyComponent (String name, String colourString, bool colourSettings = false);
     ~ColourPropertyComponent() {}
     void paint (Graphics& g)  override;
-    void mouseDown (const MouseEvent& e);
+    void mouseDown (const MouseEvent& e) override;
     void changeListenerCallback (juce::ChangeBroadcaster* source) override;
     void refresh() override {}
     String getCurrentColourString();
@@ -144,10 +144,10 @@ public :
     ColourMultiPropertyComponent (String name, var colours, bool colourSettings = false);
     ~ColourMultiPropertyComponent() {}
     void paint (Graphics& g)  override;
-    void mouseDown (const MouseEvent& e);
+    void mouseDown (const MouseEvent& e) override;
     void changeListenerCallback (juce::ChangeBroadcaster* source) override;
     void refresh() override {}
-    void resized();
+    void resized() override;
     void buttonClicked (Button* button) override;
     String getCurrentColourString();
     Colour colour;

--- a/Source/Utilities/CabbageNewProjectWindow.h
+++ b/Source/Utilities/CabbageNewProjectWindow.h
@@ -30,7 +30,7 @@ class CabbageProjectWindow : public Component, public Button::Listener
     class SimpleImageButton : public ImageButton
     {
     public:
-        SimpleImageButton (String name, CabbageProjectWindow* owner): owner (owner), name (name), ImageButton (name) {}
+        SimpleImageButton (String name, CabbageProjectWindow* owner): ImageButton (name), owner (owner), name (name) {}
         ~SimpleImageButton() {}
 
         void mouseEnter (const MouseEvent& e)
@@ -67,13 +67,13 @@ public:
         information = informationStr;
     }
 
-    void buttonClicked (Button* button);
+    void buttonClicked (Button* button) override;
 
 	void paint(Graphics& g)  override;
 
     void resized() override
     {
-        Rectangle<int> r (getLocalBounds());
+        // Rectangle<int> r (getLocalBounds());
 
         newInstrumentButton.setBounds (50, 50, 150, 150);
         newEffectButton.setBounds (250, 50, 150, 150);

--- a/Source/Utilities/CabbageSSHFileBrowser.h
+++ b/Source/Utilities/CabbageSSHFileBrowser.h
@@ -33,13 +33,13 @@ public:
     ~CabbageSSHFileBrowser();
     void paint (Graphics& g) override;
     void resized() override;
-    int getNumRows();
-    void listBoxItemDoubleClicked (int row, const MouseEvent& e);
+    int getNumRows() override;
+    void listBoxItemDoubleClicked (int row, const MouseEvent& e) override;
 
     void paintListBoxItem (int rowNumber, Graphics& g,
                            int width, int height, bool rowIsSelected) override;
 
-    void selectedRowsChanged (int /*lastRowselected*/) {};
+    void selectedRowsChanged (int /*lastRowselected*/) override {};
     ListBox filesListBox;;
     void launchChildProcess (const String command);
 
@@ -47,7 +47,7 @@ private:
     String ipAddress, homeDirectory, currentLocalFilePath;
     TextEditor currentDirectoryLabel;
     const String getFileOrFolderName (String text);
-    void textEditorReturnKeyPressed (TextEditor&);
+    void textEditorReturnKeyPressed (TextEditor&) override;
     const String getSSHLsCommand (String directory);
 
     ChildProcess childProcess;

--- a/Source/Utilities/CabbageUtilities.h
+++ b/Source/Utilities/CabbageUtilities.h
@@ -29,8 +29,10 @@
 
 class CabbageIDELookAndFeel;
 
+#ifdef _MSC_VER
 #pragma warning(disable: 4244) // possible loss of data
 #pragma warning(disable: 4100) // possible loss of data
+#endif
 
 using namespace std;
 
@@ -985,7 +987,7 @@ public:
     {
 
         PopupMenu menu;
-        int fileCnt = 0;
+        // int fileCnt = 0;
 
         if (File (userDir).exists())
         {

--- a/Source/Widgets/CabbageCheckbox.h
+++ b/Source/Widgets/CabbageCheckbox.h
@@ -44,7 +44,7 @@ public:
     void valueTreeChildOrderChanged (ValueTree&, int, int) override {}
     void valueTreeParentChanged (ValueTree&) override {};
 
-    String getTooltip()
+    String getTooltip() override
     {
         return tooltipText;
     }

--- a/Source/Widgets/CabbageComboBox.h
+++ b/Source/Widgets/CabbageComboBox.h
@@ -58,7 +58,7 @@ public:
     void valueTreeChildOrderChanged (ValueTree&, int, int) override {}
     void valueTreeParentChanged (ValueTree&) override {};
 
-    String getTooltip()
+    String getTooltip() override
     {
         return tooltipText;
     }

--- a/Source/Widgets/CabbageCustomWidgets.h
+++ b/Source/Widgets/CabbageCustomWidgets.h
@@ -35,7 +35,7 @@ public:
     ~DemoCabbageWidget() {};
 
     //ValueTree::Listener virtual methods....
-    void valueTreePropertyChanged (ValueTree& valueTree, const Identifier&);
+    void valueTreePropertyChanged (ValueTree& valueTree, const Identifier&) override;
     void valueTreeChildAdded (ValueTree&, ValueTree&)override {};
     void valueTreeChildRemoved (ValueTree&, ValueTree&, int) override {}
     void valueTreeChildOrderChanged (ValueTree&, int, int) override {}

--- a/Source/Widgets/CabbageEncoder.h
+++ b/Source/Widgets/CabbageEncoder.h
@@ -66,12 +66,12 @@ public:
     void valueTreeChildOrderChanged (ValueTree&, int, int) override {}
     void valueTreeParentChanged (ValueTree&) override {};
 
-    void labelTextChanged (Label* label);
+    void labelTextChanged (Label* label) override;
     void mouseDown (const MouseEvent& e)  override;
     void mouseEnter (const MouseEvent& e) override;
     void mouseDrag (const MouseEvent& e) override;
     void mouseExit (const MouseEvent& e) override;
-    void mouseWheelMove (const MouseEvent& event, const MouseWheelDetails& wheel);
+    void mouseWheelMove (const MouseEvent& event, const MouseWheelDetails& wheel) override;
     void paint (Graphics& g) override;
     void showPopup (int displayTime = 250);
     void resized() override;

--- a/Source/Widgets/CabbageLabel.h
+++ b/Source/Widgets/CabbageLabel.h
@@ -41,7 +41,7 @@ public:
     ~CabbageLabel() {};
 
     //ValueTree::Listener virtual methods....
-    void valueTreePropertyChanged (ValueTree& valueTree, const Identifier&);
+    void valueTreePropertyChanged (ValueTree& valueTree, const Identifier&) override;
     void valueTreeChildAdded (ValueTree&, ValueTree&)override {};
     void valueTreeChildRemoved (ValueTree&, ValueTree&, int) override {}
     void valueTreeChildOrderChanged (ValueTree&, int, int) override {}

--- a/Source/Widgets/CabbageListBox.h
+++ b/Source/Widgets/CabbageListBox.h
@@ -27,7 +27,7 @@ public:
     ~CabbageListBox() {};
 
     //ValueTree::Listener virtual methods....
-    void valueTreePropertyChanged (ValueTree& valueTree, const Identifier&);
+    void valueTreePropertyChanged (ValueTree& valueTree, const Identifier&) override;
     void valueTreeChildAdded (ValueTree&, ValueTree&)override {};
     void valueTreeChildRemoved (ValueTree&, ValueTree&, int) override {}
     void valueTreeChildOrderChanged (ValueTree&, int, int) override {}
@@ -51,13 +51,13 @@ public:
 
 
     int getNumRows() override;
-    void listBoxItemDoubleClicked(int row, const MouseEvent &e);
+    void listBoxItemDoubleClicked(int row, const MouseEvent &e) override;
     void paintListBoxItem (int rowNumber, Graphics& g,
                            int width, int height, bool rowIsSelected) override;
     void selectedRowsChanged (int /*lastRowselected*/) override;
     void addItemsToListbox (ValueTree wData);
     //void paint(Graphics& g) override;
-    void resized();
+    void resized() override;
 
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (CabbageListBox);

--- a/Source/Widgets/CabbageSignalDisplay.h
+++ b/Source/Widgets/CabbageSignalDisplay.h
@@ -67,7 +67,7 @@ public:
     ValueTree widgetData;
 
     void setBins (int min, int max);
-    void scrollBarMoved (ScrollBar* scrollBarThatHasMoved, double newRangeStart);
+    void scrollBarMoved (ScrollBar* scrollBarThatHasMoved, double newRangeStart) override;
     void changeListenerCallback (ChangeBroadcaster* source) override;
     void drawSonogram();
     void drawSpectroscope (Graphics& g);

--- a/Source/Widgets/CabbageSoundfiler.h
+++ b/Source/Widgets/CabbageSoundfiler.h
@@ -44,7 +44,7 @@ public:
     CabbageSoundfiler (ValueTree wData, CabbagePluginEditor* _owner, int sr);
     ~CabbageSoundfiler() {};
 
-    void resized();
+    void resized() override;
 
     void setFile (String newFile);
     void setWaveform (AudioSampleBuffer buffer, int channels);

--- a/Source/Widgets/Legacy/FrequencyRangeDisplayComponent.h
+++ b/Source/Widgets/Legacy/FrequencyRangeDisplayComponent.h
@@ -40,7 +40,7 @@ public:
 
     ~FrequencyRangeDisplayComponent() {}
 
-    void resized()
+    void resized() override
     {
         if (getWidth() < 400)
             resolution = resolution / 2;

--- a/Source/Widgets/Legacy/Soundfiler.cpp
+++ b/Source/Widgets/Legacy/Soundfiler.cpp
@@ -33,7 +33,7 @@ public:
     }
     ~ZoomButton() {}
 
-    void mouseDown (const MouseEvent& e)
+    void mouseDown (const MouseEvent& e) override
     {
         sendChangeMessage();
     }
@@ -55,18 +55,21 @@ public:
 // soundfiler display  component
 //==============================================================================
 
-Soundfiler::Soundfiler (int sr, Colour col, Colour bgcol):   thumbnailCache (5), colour (col),                                                        sampleRate (sr),
-    currentPlayPosition (0),
+Soundfiler::Soundfiler (int sr, Colour col, Colour bgcol):
+    selectableRange (true),
+    showScrubber (true),
+    currentPositionMarker (new DrawableRectangle()),
+    scrubberPosition (0),
+    sampleRate (sr),
+    regionWidth (1),
+    thumbnailCache (5),
+    colour (col),
+    bgColour (bgcol),
     mouseDownX (0),
     mouseUpX (0),
-    drawWaveform (false),
-    regionWidth (1),
     loopLength (0),
-    scrubberPosition (0),
-    showScrubber (true),
-    selectableRange (true),
-    bgColour (bgcol),
-    currentPositionMarker (new DrawableRectangle())
+    currentPlayPosition (0),
+    drawWaveform (false)
 {
     formatManager.registerBasicFormats();
     thumbnail = new AudioThumbnail (2, formatManager, thumbnailCache);

--- a/Source/Widgets/Legacy/Soundfiler.h
+++ b/Source/Widgets/Legacy/Soundfiler.h
@@ -85,7 +85,7 @@ public:
 
     void setZoomFactor (double amount);
     void setFile (const File& file);
-    void mouseWheelMove (const MouseEvent&, const MouseWheelDetails& wheel);
+    void mouseWheelMove (const MouseEvent&, const MouseWheelDetails& wheel) override;
     void setWaveform (AudioSampleBuffer buffer, int channels);
     void createImage (String filename);
 
@@ -100,16 +100,16 @@ private:
     ScopedPointer<DrawableRectangle> currentPositionMarker;
     ScopedPointer<ScrollBar> scrollbar;
     void setRange (Range<double> newRange);
-    void resized();
-    void paint (Graphics& g);
-    void mouseDown (const MouseEvent& e);
-    void mouseUp (const MouseEvent& e);
-    void mouseEnter (const MouseEvent& e);
-    void mouseDrag (const MouseEvent& e);
-    void mouseExit (const MouseEvent& e);
+    void resized() override;
+    void paint (Graphics& g) override;
+    void mouseDown (const MouseEvent& e) override;
+    void mouseUp (const MouseEvent& e) override;
+    void mouseEnter (const MouseEvent& e) override;
+    void mouseDrag (const MouseEvent& e) override;
+    void mouseExit (const MouseEvent& e) override;
     bool reDraw;
     double scrubberPosition;
-    void scrollBarMoved (ScrollBar* scrollBarThatHasMoved, double newRangeStart);
+    void scrollBarMoved (ScrollBar* scrollBarThatHasMoved, double newRangeStart) override;
     void changeListenerCallback (ChangeBroadcaster* source) override;
     ScopedPointer<ZoomButton> zoomIn, zoomOut;
 

--- a/Source/Widgets/Legacy/TableManager.h
+++ b/Source/Widgets/Legacy/TableManager.h
@@ -59,7 +59,7 @@ public:
     void setTableColours (var colours);
     void setBackgroundColour (Colour col);
     void repaintAllTables();
-    void resized();
+    void resized() override;
     void setZoomFactor (double zoom);
     void setDrawMode (String mode);
     void showScrollbar (bool show);
@@ -74,7 +74,7 @@ public:
     void scroll (double newRangeStart);
     void addTable (int sr, const Colour col, int gen, var ampRange, int ftnumber, ChangeListener* listener);
     void setWaveform (AudioSampleBuffer buffer, int ftNumber);
-    void scrollBarMoved (ScrollBar* scrollBarThatHasMoved, double newRangeStart);
+    void scrollBarMoved (ScrollBar* scrollBarThatHasMoved, double newRangeStart) override;
     void setWaveform (Array<float, CriticalSection> buffer, int ftNumber, bool updateRange = true);
     void setFile (const File file);
     void enableEditMode (StringArray pFields, int ftnumber);
@@ -135,7 +135,7 @@ public:
     void setSampleRange (double pos, double end);
     void setZoomFactor (double amount);
     void setFile (const File& file);
-    void mouseWheelMove (const MouseEvent&, const MouseWheelDetails& wheel);
+    void mouseWheelMove (const MouseEvent&, const MouseWheelDetails& wheel) override;
     void setWaveform (AudioSampleBuffer buffer);
     void enableEditMode (StringArray pFields);
     Point<int> tableTopAndHeight;
@@ -152,7 +152,7 @@ public:
     Range<double> globalRange;
     bool isTableOnTop;
     ScopedPointer<ScrollBar> scrollbar;
-    void resized();
+    void resized() override;
     Range<double> visibleRange;
     bool drawGrid;
     int scrollbarReduction;
@@ -253,7 +253,7 @@ private:
     void mouseExit (const MouseEvent& e)  override;
     bool reDraw;
     double scrubberPosition;
-    void scrollBarMoved (ScrollBar* scrollBarThatHasMoved, double newRangeStart);
+    void scrollBarMoved (ScrollBar* scrollBarThatHasMoved, double newRangeStart) override;
     void changeListenerCallback (ChangeBroadcaster* source) override;
     ScopedPointer<HandleViewer> handleViewer;
     AudioFormatManager formatManager;


### PR DESCRIPTION
This fixes a decent amount of compiler warnings coming from gcc.
On this compiler, it's difficult to get a useful build log because of too many warnings, particularly there reoccurring from headers.

It's not all there is, and the cleaner log seems to put to light a few defects as well.
I'll post more info on this a later time.