### PR TITLE
Fix warnings

### DIFF
--- a/Source/Application/CabbageMainComponent.h
+++ b/Source/Application/CabbageMainComponent.h
@@ -130,6 +130,7 @@ public:
                 return fileTab;
         }
         jassertfalse;
+        return nullptr;
     }
     
     //overlaying this component on FileBrowserComponent to take contorl of up button colour..

--- a/Source/Audio/Plugins/CsoundPluginProcessor.cpp
+++ b/Source/Audio/Plugins/CsoundPluginProcessor.cpp
@@ -231,7 +231,7 @@ void CsoundPluginProcessor::initAllCsoundChannels (ValueTree cabbageData)
         csound->SetChannel ("CSD_PATH", csdFilePath.getFullPathName().toUTF8().getAddress());
     }
 
-    csound->SetStringChannel ("LAST_FILE_DROPPED", "");
+    csound->SetStringChannel ("LAST_FILE_DROPPED", const_cast<char*> (""));
 
     csdFilePath.setAsCurrentWorkingDirectory();
 

--- a/Source/Settings/CabbageSettings.h
+++ b/Source/Settings/CabbageSettings.h
@@ -72,7 +72,7 @@ private:
     void changed()
     {
 		std::unique_ptr<XmlElement> data(valueTree.createXml());
-        getUserSettings()->setValue ("PROJECT_DEFAULT_SETTINGS", &data);
+        getUserSettings()->setValue ("PROJECT_DEFAULT_SETTINGS", data.get());
         sendChangeMessage();
         //XmlElement * el = valueTree.createXml();
         //el->writeToFile(File("/home/rory/Desktop/Example1.xml"), String::empty);

--- a/Source/Utilities/CabbageExportPlugin.cpp
+++ b/Source/Utilities/CabbageExportPlugin.cpp
@@ -71,8 +71,8 @@ void PluginExporter::exportPlugin (String type, File csdFile, String pluginId, S
         }
         else  if (type == "FMOD")
         {
-            fileExtension = SystemStats::getOperatingSystemType() & SystemStats::MacOSX != 0 ? String("dll") : String("dylib");
-            pluginFilename = currentApplicationDirectory + (SystemStats::getOperatingSystemType() & SystemStats::MacOSX != 0 ? String("/fmod_csoundL64.dll") : String("/fmod_csound.dylib"));
+            fileExtension = ((SystemStats::getOperatingSystemType() & SystemStats::MacOSX) != 0) ? String("dylib") : String("dll");
+            pluginFilename = currentApplicationDirectory + (((SystemStats::getOperatingSystemType() & SystemStats::MacOSX) != 0) ? String("/fmod_csound.dylib") : String("/fmod_csoundL64.dll"));
             
         }
 

--- a/Source/Widgets/CabbageEventSequencer.cpp
+++ b/Source/Widgets/CabbageEventSequencer.cpp
@@ -263,8 +263,8 @@ bool CabbageEventSequencer::keyPressed (const KeyPress& key, Component* originat
 
         setCellData(currentColumn, currentRow, ted->getText()+key.getTextCharacter());
 
-        if (key.getModifiers().isCtrlDown() && key.isKeyCode (KeyPress::rightKey) ||
-            key.getModifiers().isCtrlDown() && key.isKeyCode (KeyPress::leftKey) ||
+        if ((key.getModifiers().isCtrlDown() && key.isKeyCode (KeyPress::rightKey)) ||
+            (key.getModifiers().isCtrlDown() && key.isKeyCode (KeyPress::leftKey)) ||
             key.isKeyCode (KeyPress::downKey) ||
             key.isKeyCode (KeyPress::upKey) ||
             key.isKeyCode (KeyPress::returnKey))

--- a/Source/Widgets/Legacy/TableManager.cpp
+++ b/Source/Widgets/Legacy/TableManager.cpp
@@ -1629,7 +1629,7 @@ void HandleComponent::paint (Graphics& g)
         else
         {
             g.setColour (colour);
-            g.drawRoundedRectangle (getLocalBounds().reduced (1.2f).toFloat(), 2.f, 1.f);
+            g.drawRoundedRectangle (getLocalBounds().toFloat().reduced (1.2f), 2.f, 1.f);
             g.setColour (colour.withAlpha (.7f));
             g.drawRoundedRectangle (getLocalBounds().toFloat(), 2.f, 1.f);
         }


### PR DESCRIPTION
It fixes the other warnings which aren't about deprecation.

- In `CabageSettings.h` an apparent bug should be resolved.
The `bool` overload of `setValue` has been invoked on `PropertySet`, instead of the `XmlElement*` one.
It was found by the warning about pointer-to-bool conversion.

- In `CabbageExportPlugin.cpp` the condition for detecting Mac appears to be reversed.

- There remains one warning at this location, of which I'm not sure how to fix.
There may or may not be a programming mistake at this location.

https://github.com/rorywalsh/cabbage/blob/9322a0833efbb3685a1a4f941fe61104bb4b7451/Source/Widgets/CabbageWidgetDataTextMethods.cpp#L593

```
../../Source/Widgets/CabbageWidgetDataTextMethods.cpp:593:69: warning: '&&' within '||' [-Wlogical-op-parentheses]
  ...|| type.contains("checkbox") && (identifier == "fontcolour" || identifier == "fontcolour:1"))
     ~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../Source/Widgets/CabbageWidgetDataTextMethods.cpp:593:69: note: place parentheses around the '&&' expression to
      silence this warning
  ...|| type.contains("checkbox") && (identifier == "fontcolour" || identifier == "fontcolour:1"))
                                  ^
```
