### PR TITLE
fix warnings about deprecation of ScopedPointer

### DIFF
--- a/Source/Application/CabbageDocumentWindow.cpp
+++ b/Source/Application/CabbageDocumentWindow.cpp
@@ -32,9 +32,9 @@ enum
 CabbageDocumentWindow::CabbageDocumentWindow (String name, String commandLineParams) : DocumentWindow (name,
     Colours::lightgrey,
     DocumentWindow::allButtons),
+    pluginExporter(),
     lookAndFeel (new FlatButtonLookAndFeel()),
-    commandLineArgs (commandLineParams),
-    pluginExporter()
+    commandLineArgs (commandLineParams)
 {
     setTitleBarButtonsRequired (DocumentWindow::allButtons, false);
     setUsingNativeTitleBar (false/*true*/);
@@ -43,17 +43,17 @@ CabbageDocumentWindow::CabbageDocumentWindow (String name, String commandLinePar
     centreWithSize (getWidth(), getHeight());
     setVisible (true);
 
-    Desktop::getInstance().setDefaultLookAndFeel (lookAndFeel); //set default look and feel for project
+    Desktop::getInstance().setDefaultLookAndFeel (lookAndFeel.get()); //set default look and feel for project
     getLookAndFeel().setColour (PopupMenu::ColourIds::highlightedBackgroundColourId, Colour (200, 200, 200));
 
     initSettings();
     pluginExporter.settingsToUse(cabbageSettings->getUserSettings());
     setColour (backgroundColourId, CabbageSettings::getColourFromValueTree (cabbageSettings->valueTree, CabbageColourIds::mainBackground, Colours::lightgrey));
-    setContentOwned (content = new CabbageMainComponent (this, cabbageSettings), true);
+    setContentOwned (content = new CabbageMainComponent (this, cabbageSettings.get()), true);
     content->propertyPanel->setVisible (false);
     cabbageSettings->addChangeListener (content);
     setMenuBar (this, 18/*25*/);
-    getMenuBarComponent()->setLookAndFeel (getContentComponent()->lookAndFeel);
+    getMenuBarComponent()->setLookAndFeel (getContentComponent()->lookAndFeel.get());
 
 
     if (commandLineArgs.isNotEmpty())
@@ -135,7 +135,7 @@ CabbageDocumentWindow::CabbageDocumentWindow (String name, String commandLinePar
 #if JUCE_MAC
     MenuBarModel::setMacMainMenu (this, nullptr, "Open Recent");
 #endif
-    setLookAndFeel (lookAndFeel); //(&getContentComponent()->getLookAndFeel());
+    setLookAndFeel (lookAndFeel.get()); //(&getContentComponent()->getLookAndFeel());
     lookAndFeelChanged();
 
 
@@ -160,7 +160,7 @@ void CabbageDocumentWindow::initSettings()
     options.folderName          = "Cabbage2";
 #endif
 
-    cabbageSettings = new CabbageSettings();
+    cabbageSettings.reset (new CabbageSettings());
     cabbageSettings->setStorageParameters (options);
     cabbageSettings->setDefaultSettings();
 }

--- a/Source/Application/CabbageDocumentWindow.h
+++ b/Source/Application/CabbageDocumentWindow.h
@@ -61,7 +61,7 @@ public:
     //void maximiseButtonPressed() override;
     void focusGained (FocusChangeType cause) override; //grab focus when user clicks on editor
 
-    ScopedPointer<CabbageSettings> cabbageSettings;
+    std::unique_ptr<CabbageSettings> cabbageSettings;
     ApplicationCommandTarget* getNextCommandTarget() override   {        return findFirstTargetParentComponent();    }
     ApplicationCommandManager& getCommandManager() {     return commandManager;  }
     void exportExamplesToPlugins(String type);
@@ -79,10 +79,10 @@ private:
     //=======================================================
 
     PluginExporter pluginExporter;
-    ScopedPointer<FlatButtonLookAndFeel> lookAndFeel;
+    std::unique_ptr<FlatButtonLookAndFeel> lookAndFeel;
     String commandLineArgs = "";
     bool isGUIEnabled = false;
-    ScopedPointer<CabbageMainComponent> content;
+    CabbageMainComponent* content = nullptr;
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (CabbageDocumentWindow)
 };
 

--- a/Source/Application/CabbageMainComponent.h
+++ b/Source/Application/CabbageMainComponent.h
@@ -194,7 +194,7 @@ public:
     CabbageSettings* getCabbageSettings() {      return cabbageSettings; }
     FilterGraph* getFilterGraph() {                return graphComponent->graph.get();  }
     //==============================================================================
-    ScopedPointer<CabbagePropertiesPanel> propertyPanel;
+    std::unique_ptr<CabbagePropertiesPanel> propertyPanel;
 	void togglePropertyPanel()
 	{
 		if (getCurrentCodeEditor())
@@ -206,7 +206,7 @@ public:
     
     CabbagePluginEditor* currentEditor = nullptr;
     OwnedArray<CabbageEditorContainer> editorAndConsole;
-    ScopedPointer<CabbageIDELookAndFeel> lookAndFeel;
+    std::unique_ptr<CabbageIDELookAndFeel> lookAndFeel;
     Toolbar toolbar;
     
     void openFolder();
@@ -271,7 +271,7 @@ public:
     void toggleBrowser(); 
     
 //    TimeSliceThread directoryThread{ "File Scanner Thread" };
-     ScopedPointer<WildcardFileFilter> wildcardFilter;
+     std::unique_ptr<WildcardFileFilter> wildcardFilter;
 //    DirectoryContentsList fileList{ &wildcardFilter, directoryThread };
 //    FileTreeComponent fileTree{ fileList };
     FileBrowserComponent fileTree;
@@ -299,19 +299,19 @@ private:
     CabbageSettings* cabbageSettings;
     int currentFileIndex = 0;
     int numberOfFiles = 0;
-    //ScopedPointer<FilterGraph> filterGraph;
+    //std::unique_ptr<FilterGraph> filterGraph;
     bool isGUIEnabled = false;
     String consoleMessages;
     const int toolbarThickness = 35;
     class FindPanel;
-    ScopedPointer<FindPanel> findPanel;
+    std::unique_ptr<FindPanel> findPanel;
 
 
-	ScopedPointer<GraphDocumentComponent> graphComponent;
-    ScopedPointer<FilterGraphDocumentWindow> filterGraphWindow;
+    GraphDocumentComponent* graphComponent = nullptr;
+    std::unique_ptr<FilterGraphDocumentWindow> filterGraphWindow;
 
 
-    //ScopedPointer<HtmlHelpDocumentWindow> helpWindow;
+    //std::unique_ptr<HtmlHelpDocumentWindow> helpWindow;
 
     //==============================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (CabbageMainComponent)

--- a/Source/Audio/Filters/FilterGraph.h
+++ b/Source/Audio/Filters/FilterGraph.h
@@ -239,7 +239,7 @@ public:
 
 		if (auto* plugin = graph.getNodeForId(nodeId))
 		{
-			ScopedPointer<XmlElement> xml = createConnectionsXml();
+			std::unique_ptr<XmlElement> xml (createConnectionsXml());
 			graph.disconnectNode(nodeId);
 			plugin->getProcessor()->editorBeingDeleted(plugin->getProcessor()->getActiveEditor());
 			

--- a/Source/Audio/Plugins/CabbagePluginEditor.cpp
+++ b/Source/Audio/Plugins/CabbagePluginEditor.cpp
@@ -23,19 +23,21 @@ class CabbageCheckbox;
 //==============================================================================
 CabbagePluginEditor::CabbagePluginEditor (CabbagePluginProcessor& p)
     : AudioProcessorEditor (&p),
-      processor (p),
+      mainComponent(),
       lookAndFeel(),
+      processor (p)
 #ifdef Cabbage_IDE_Build
-      layoutEditor (processor.cabbageWidgets),
+    , layoutEditor (processor.cabbageWidgets)
 #endif
-      mainComponent()
 {
     setName ("PluginEditor");
     setLookAndFeel (&lookAndFeel);
-    addAndMakeVisible(viewportContainer = new ViewportContainer());
+    viewportContainer.reset (new ViewportContainer());
+    addAndMakeVisible(viewportContainer.get());
     viewportContainer->addAndMakeVisible(mainComponent);
-    addAndMakeVisible (viewport = new Viewport());
-    viewport->setViewedComponent(viewportContainer, false);
+    viewport.reset (new Viewport());
+    addAndMakeVisible (viewport.get());
+    viewport->setViewedComponent(viewportContainer.get(), false);
     viewport->setScrollBarsShown(false, false);
     mainComponent.setInterceptsMouseClicks (false, true);
     setSize (50, 50);
@@ -608,7 +610,7 @@ void CabbagePluginEditor::buttonClicked(Button* button)
 	{
 		const StringArray textItems = cabbageButton->getTextArray();
 		const ValueTree valueTree = CabbageWidgetData::getValueTreeForComponent(processor.cabbageWidgets, cabbageButton->getName());
-		const int latched = CabbageWidgetData::getNumProp(valueTree, CabbageIdentifierIds::latched);
+		// const int latched = CabbageWidgetData::getNumProp(valueTree, CabbageIdentifierIds::latched);
 
 		if (textItems.size() > 0)
 			cabbageButton->setButtonText(textItems[buttonState == false ? 0 : 1]);

--- a/Source/Audio/Plugins/CabbagePluginEditor.h
+++ b/Source/Audio/Plugins/CabbagePluginEditor.h
@@ -278,8 +278,8 @@ private:
         }
     };
 
-    ScopedPointer<Viewport> viewport;
-    ScopedPointer<ViewportContainer> viewportContainer;
+    std::unique_ptr<Viewport> viewport;
+    std::unique_ptr<ViewportContainer> viewportContainer;
     OwnedArray<Component> components;
     Array<Component*> radioComponents;
     OwnedArray<PopupDocumentWindow> popupPlants;

--- a/Source/Audio/Plugins/CsoundPluginProcessor.h
+++ b/Source/Audio/Plugins/CsoundPluginProcessor.h
@@ -155,7 +155,7 @@ public:
 
     Csound* getCsound()
     {
-        return csound;
+        return csound.get();
     }
 
     CSOUND* getCsoundStruct()
@@ -231,7 +231,7 @@ private:
     int guiRefreshRate = 128;
     MidiBuffer midiBuffer;
     String csoundOutput;
-    ScopedPointer<CSOUND_PARAMS> csoundParams;
+    std::unique_ptr<CSOUND_PARAMS> csoundParams;
     int csCompileResult = -1;
     int numCsoundChannels, pos;
     bool updateSignalDisplay = false;
@@ -241,8 +241,8 @@ private:
     int csndIndex;
     int csdKsmps;
     File csdFile , csdFilePath;
-    ScopedPointer<Csound> csound;
-    ScopedPointer<FileLogger> fileLogger;
+    std::unique_ptr<Csound> csound;
+    std::unique_ptr<FileLogger> fileLogger;
     int busIndex = 0;
     bool disableLogging = false;
 

--- a/Source/Cabbage.cpp
+++ b/Source/Cabbage.cpp
@@ -30,7 +30,7 @@ Cabbage::Cabbage()
 //==============================================================================
 void Cabbage::initialise (const String& commandLine)
 {
-    documentWindow = new CabbageDocumentWindow (getApplicationName(), getCommandLineParameters());
+    documentWindow.reset (new CabbageDocumentWindow (getApplicationName(), getCommandLineParameters()));
 
     if (commandLine.isNotEmpty())
     {

--- a/Source/Cabbage.h
+++ b/Source/Cabbage.h
@@ -61,7 +61,7 @@ public:
 
 
 private:
-    ScopedPointer<CabbageDocumentWindow> documentWindow;
+    std::unique_ptr<CabbageDocumentWindow> documentWindow;
 };
 
 

--- a/Source/CodeEditor/CabbageCodeEditor.cpp
+++ b/Source/CodeEditor/CabbageCodeEditor.cpp
@@ -25,14 +25,14 @@
 //==============================================================================
 CabbageCodeEditorComponent::CabbageCodeEditorComponent (CabbageEditorContainer* owner, Component* statusBar, ValueTree valueTree, CodeDocument& document, CodeTokeniser* codeTokeniser)
     : CodeEditorComponent (document, codeTokeniser),
-      valueTree (valueTree),
-      statusBar (statusBar),
-      owner (owner),
-      autoCompleteListBox(),
       Thread ("parseVariablesThread"),
-      debugLabel (""),
+      statusBar (statusBar),
+      autoCompleteListBox(),
+      owner (owner),
+      lookAndFeel3(),
+      valueTree (valueTree),
       currentLineMarker(),
-      lookAndFeel3()
+      debugLabel ("")
 {
     //setMouseClickGrabsKeyboardFocus (true);
     String opcodeFile = File (File::getSpecialLocation (File::currentExecutableFile)).getParentDirectory().getFullPathName();
@@ -40,7 +40,7 @@ CabbageCodeEditorComponent::CabbageCodeEditorComponent (CabbageEditorContainer* 
     this->setLookAndFeel (&lookAndFeel3);
     setScrollbarThickness (20);
 
-    addToGUIEditorPopup = new AddCodeToGUIEditorComponent (this, "Add to code repository", Colour (25, 25, 25));
+    addToGUIEditorPopup.reset (new AddCodeToGUIEditorComponent (this, "Add to code repository", Colour (25, 25, 25)));
     addToGUIEditorPopup->setVisible (false);
 
     if (File (opcodeFile).existsAsFile())
@@ -273,7 +273,7 @@ void CabbageCodeEditorComponent::updateCurrenLineMarker (ArrowKeys arrowKey)
     const Range<int> highlight (getHighlightedRegion());
     CodeDocument::Position start;
     CodeDocument::Position linePos (getDocument(), getCaretPos().getPosition());
-    bool draggingBackwards = false;
+    // bool draggingBackwards = false;
 
     if ( highlight.getLength() > 0)
     {
@@ -381,7 +381,7 @@ void CabbageCodeEditorComponent::codeDocumentTextInserted (const String& text, i
     lastAction = "insertText";
     const CodeDocument::Position pos (getDocument(), startIndex);
 
-    const int lineNumber = pos.getLineNumber();
+    // const int lineNumber = pos.getLineNumber();
     if(range.contains(pos.getLineNumber()) == false)
         handleAutoComplete (text);
 }
@@ -919,7 +919,7 @@ void CabbageCodeEditorComponent::AddCodeToGUIEditorComponent::textEditorReturnKe
     if (editor.getText() != "Enter name for GUI code")
     {
         std::unique_ptr<XmlElement> repoXml;
-        XmlElement* newEntryXml;
+        // XmlElement* newEntryXml;
         repoXml = owner->owner->settings->getUserSettings()->getXmlValue ("CopeRepoXmlData");
 
         if (!repoXml)
@@ -965,7 +965,7 @@ StringArray CabbageCodeEditorComponent::addItemsToPopupMenu (PopupMenu& m)
 {
     StringArray customCodeSnippets;
     std::unique_ptr<XmlElement> repoXml;
-    XmlElement* newEntryXml, *newEntryXml1;
+    // XmlElement* newEntryXml, *newEntryXml1;
 
     repoXml = owner->settings->getUserSettings()->getXmlValue ("CopeRepoXmlData");
 

--- a/Source/CodeEditor/CabbageCodeEditor.h
+++ b/Source/CodeEditor/CabbageCodeEditor.h
@@ -143,7 +143,7 @@ public:
 
     };
 
-    ScopedPointer<AddCodeToGUIEditorComponent> addToGUIEditorPopup;
+    std::unique_ptr<AddCodeToGUIEditorComponent> addToGUIEditorPopup;
 
     void run() override// thread for parsing text for variables on startup
     {

--- a/Source/CodeEditor/CabbageEditorContainer.cpp
+++ b/Source/CodeEditor/CabbageEditorContainer.cpp
@@ -21,17 +21,25 @@
 #include "../Application/CabbageMainComponent.h"
 
 CabbageEditorContainer::CabbageEditorContainer (CabbageSettings* settings, bool isCsd)
-    : settings (settings), isCsdFile (isCsd),
-      statusBar (settings->valueTree, this)
+    : statusBar (settings->valueTree, this),
+      settings (settings),
+      isCsdFile (isCsd)
 {
     addAndMakeVisible (statusBar);
 
     if (isCsdFile)
-        addAndMakeVisible (editor = new CabbageCodeEditorComponent (this, &statusBar, settings->valueTree, csoundDocument, &csoundTokeniser));
+    {
+        editor.reset (new CabbageCodeEditorComponent (this, &statusBar, settings->valueTree, csoundDocument, &csoundTokeniser));
+        addAndMakeVisible (editor.get());
+    }
     else
-        addAndMakeVisible (editor = new CabbageCodeEditorComponent (this, &statusBar, settings->valueTree, csoundDocument, &javaTokeniser));
+    {
+        editor.reset (new CabbageCodeEditorComponent (this, &statusBar, settings->valueTree, csoundDocument, &javaTokeniser));
+        addAndMakeVisible (editor.get());
+    }
 
-    addAndMakeVisible (outputConsole = new CabbageOutputConsole (settings->valueTree));
+    outputConsole.reset (new CabbageOutputConsole (settings->valueTree));
+    addAndMakeVisible (outputConsole.get());
 
     editor->setLineNumbersShown (true);
     editor->addMouseListener (this, true);

--- a/Source/CodeEditor/CabbageEditorContainer.h
+++ b/Source/CodeEditor/CabbageEditorContainer.h
@@ -82,8 +82,8 @@ public:
 
     int getStatusBarPosition();
     void hideOutputConsole();
-    ScopedPointer<CabbageCodeEditorComponent> editor;
-    ScopedPointer<CabbageOutputConsole> outputConsole;
+    std::unique_ptr<CabbageCodeEditorComponent> editor;
+    std::unique_ptr<CabbageOutputConsole> outputConsole;
     StatusBar statusBar;
     CodeDocument csoundDocument;
     CsoundTokeniser csoundTokeniser;

--- a/Source/CodeEditor/CabbageOutputConsole.h
+++ b/Source/CodeEditor/CabbageOutputConsole.h
@@ -24,13 +24,14 @@
 
 class CabbageOutputConsole : public Component
 {
-    ScopedPointer<TextEditor> textEditor;
+    std::unique_ptr<TextEditor> textEditor;
     int fontSize;
     Typeface::Ptr fontPtr;
 public:
     CabbageOutputConsole (ValueTree valueTree): Component(), value (valueTree)
     {
-        addAndMakeVisible (textEditor = new TextEditor(), true);
+        textEditor.reset (new TextEditor());
+        addAndMakeVisible (textEditor.get(), true);
         textEditor->setColour (Label::outlineColourId, Colours::white);
         textEditor->setColour (TextEditor::textColourId, CabbageSettings::getColourFromValueTree (valueTree, CabbageColourIds::consoleText, Colours::grey.darker()));
         textEditor->setColour (TextEditor::backgroundColourId, CabbageSettings::getColourFromValueTree (valueTree, CabbageColourIds::consoleBackground, Colours::grey.darker()));

--- a/Source/GUIEditor/CabbagePropertiesPanel.cpp
+++ b/Source/GUIEditor/CabbagePropertiesPanel.cpp
@@ -95,11 +95,11 @@ CabbagePropertiesPanel::CabbagePropertiesPanel (ValueTree widgetData)
     setOpaque (true);
     setSize (300, 500);
     
-    propertyPanelLook = new PropertyPanelLookAndFeel();
-    propertyPanel.setLookAndFeel (propertyPanelLook);
+    propertyPanelLook.reset (new PropertyPanelLookAndFeel());
+    propertyPanel.setLookAndFeel (propertyPanelLook.get());
     
-    flatLook = new FlatButtonLookAndFeel();
-    hideButton.setLookAndFeel (flatLook);
+    flatLook.reset (new FlatButtonLookAndFeel());
+    hideButton.setLookAndFeel (flatLook.get());
     hideButton.setColour(TextButton::ColourIds::buttonColourId, backgroundColour);// Colours::black);
     hideButton.setColour(TextButton::ColourIds::textColourOffId, backgroundColour.contrasting(1.0f));//Colours::white);
 
@@ -131,7 +131,7 @@ void CabbagePropertiesPanel::saveOpenessState()
     if (getSectionState (name) == nullptr)
         sectionStates.add (new SectionState (name, propertyPanel.getOpennessState().get()));
     else
-        getSectionState (name)->xmlElement = propertyPanel.getOpennessState().get();
+        getSectionState (name)->xmlElement = propertyPanel.getOpennessState();
 
 }
 

--- a/Source/GUIEditor/CabbagePropertiesPanel.h
+++ b/Source/GUIEditor/CabbagePropertiesPanel.h
@@ -93,7 +93,7 @@ private:
         SectionState (String name, XmlElement* xml): name (name), xmlElement (xml)
         {}
         String name;
-        ScopedPointer<XmlElement> xmlElement;
+        std::unique_ptr<XmlElement> xmlElement;
     };
 
     OwnedArray<SectionState> sectionStates;
@@ -111,8 +111,8 @@ private:
 
     ValueTree widgetData;
 	TextButton hideButton;
-    ScopedPointer<FlatButtonLookAndFeel> flatLook;
-    ScopedPointer<PropertyPanelLookAndFeel> propertyPanelLook;
+    std::unique_ptr<FlatButtonLookAndFeel> flatLook;
+    std::unique_ptr<PropertyPanelLookAndFeel> propertyPanelLook;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (CabbagePropertiesPanel)
 };

--- a/Source/GUIEditor/ComponentOverlay.cpp
+++ b/Source/GUIEditor/ComponentOverlay.cpp
@@ -11,14 +11,14 @@
 #include "../Audio/Plugins/CabbagePluginEditor.h"
 
 ComponentOverlay::ComponentOverlay (Component* targetChild, ComponentLayoutEditor* owner)
-    :   target (targetChild), layoutEditor (owner), lookAndFeel()
+    :   target (targetChild), lookAndFeel(), layoutEditor (owner)
 {
-    resizeContainer = new ComponentBoundsConstrainer();
+    resizeContainer.reset (new ComponentBoundsConstrainer());
     resizeContainer->setMinimumSize (10, 10); //set minimum size so objects cant be resized too small
-    resizer = new ResizableBorderComponent (this, resizeContainer);
+    resizer = new ResizableBorderComponent (this, resizeContainer.get());
     addAndMakeVisible (resizer);
     resizer->addMouseListener (this, false);
-    constrainer = new ComponentBoundsConstrainer();
+    constrainer.reset (new ComponentBoundsConstrainer());
     interest = "none";
     userAdjusting = false;
     updateFromTarget ();
@@ -210,7 +210,7 @@ void ComponentOverlay::mouseDrag (const MouseEvent& e)
 
             if (multipleSelection == false)
             {
-                dragger.dragComponent (this, e, constrainer);
+                dragger.dragComponent (this, e, constrainer.get());
                 applyToTarget ();
             }
 

--- a/Source/GUIEditor/ComponentOverlay.h
+++ b/Source/GUIEditor/ComponentOverlay.h
@@ -58,7 +58,7 @@ public:
 
 private:
     CriticalSection bounds;
-    ScopedPointer<ComponentBoundsConstrainer>  constrainer;
+    std::unique_ptr<ComponentBoundsConstrainer>  constrainer;
     ComponentDragger dragger;
     SafePointer<Component> target;
     Array<juce::Rectangle<int> > childBounds;
@@ -66,7 +66,7 @@ private:
     String interest;
     bool userAdjusting;
     Rectangle<int> startBounds;
-    ScopedPointer<ComponentBoundsConstrainer> resizeContainer;
+    std::unique_ptr<ComponentBoundsConstrainer> resizeContainer;
     ResizableBorderComponent* resizer;
     ComponentLayoutEditor* layoutEditor;
 

--- a/Source/LookAndFeel/CabbageLookAndFeel2.cpp
+++ b/Source/LookAndFeel/CabbageLookAndFeel2.cpp
@@ -83,7 +83,7 @@ void CabbageLookAndFeel2::setDefaultFont(File fontFile)
 {
 //    if(fontFile.existsAsFile())
 //    {
-//        ScopedPointer<InputStream> inStream = fontFile.createInputStream();
+//        std::unique_ptr<InputStream> inStream (fontFile.createInputStream());
 //        MemoryBlock mb;
 //        inStream->readIntoMemoryBlock(mb);
 //        Typeface::Ptr fontPtr = Typeface::createSystemTypefaceFor (mb.getData(), mb.getSize());

--- a/Source/Settings/CabbageSettings.cpp
+++ b/Source/Settings/CabbageSettings.cpp
@@ -37,9 +37,8 @@ void CabbageSettings::setDefaultColourSettings()
 
 void CabbageSettings::setDefaultSettings()
 {
-    defaultPropSet = new PropertySet();
-    ScopedPointer<XmlElement> xml;
-    xml = new XmlElement ("PLANTS");
+    defaultPropSet.reset (new PropertySet());
+    std::unique_ptr<XmlElement> xml (new XmlElement ("PLANTS"));
     String homeDir = File::getSpecialLocation (File::userHomeDirectory).getFullPathName();
     String manualPath, examplesDir, cabbageHelp, themePath;
 
@@ -94,7 +93,7 @@ void CabbageSettings::setDefaultSettings()
     defaultPropSet->setValue ("SetAlwaysOnTopGraph", 0);
     defaultPropSet->setValue ("GridSize", 4);
     defaultPropSet->setValue ("CompileOnSave", 1);
-    defaultPropSet->setValue ("PlantRepository", xml);
+    defaultPropSet->setValue ("PlantRepository", xml.get());
     defaultPropSet->setValue ("EditorColourScheme", 0);
     defaultPropSet->setValue ("showTabs", 1);
     defaultPropSet->setValue ("showTabs", 1);
@@ -158,7 +157,7 @@ void CabbageSettings::setDefaultSettings()
 	defaultPropSet->setValue ("Colours_" + CabbageColourIds::fileTabText, "ffffffff");
 	defaultPropSet->setValue("Colours_" + CabbageColourIds::fileTabPlayButton, "ff323e44");
 	defaultPropSet->setValue ("Colours_" + CabbageColourIds::patcher, Colour(200, 200, 200).toString());
-    getUserSettings()->setFallbackPropertySet (defaultPropSet);
+    getUserSettings()->setFallbackPropertySet (defaultPropSet.get());
 
     valueTree.addChild (ValueTree ("Colours"), -1, 0);
     const StringArray colourIDStrings = CabbageStrings::getColourIDStrings();

--- a/Source/Settings/CabbageSettings.h
+++ b/Source/Settings/CabbageSettings.h
@@ -48,7 +48,7 @@ public:
     XmlElement* getXML (String identifier);
     void setDefaultSettings();
     void setDefaultColourSettings();
-    ScopedPointer<PropertySet> defaultPropSet;
+    std::unique_ptr<PropertySet> defaultPropSet;
     ValueTree valueTree;
     RecentlyOpenedFilesList recentFiles;
     File getMostRecentFile (int index);

--- a/Source/Settings/CabbageSettingsWindow.cpp
+++ b/Source/Settings/CabbageSettingsWindow.cpp
@@ -42,23 +42,23 @@ CabbageSettingsWindow::CabbageSettingsWindow (CabbageSettings& settings, AudioDe
     Component (""),
     settings (settings),
     listBox (this),
-    valueTree (settings.getValueTree()),
-    audioSettingsButton ("AudioSettingsButton"),
-    miscSettingsButton ("MiscSettingsButton"),
-    colourSettingsButton ("ColourSettingsButton"),
-    codeRepoButton ("CodeRepoButton"),
     audioDeviceSelector (audioDevice),
-    viewport ("AudioSettingsViewport"),
+    valueTree (settings.getValueTree()),
     deleteRepoButton ("Delete/Remove"),
-    saveRepoButton ("Save/Update")
+    saveRepoButton ("Save/Update"),
+    audioSettingsButton ("AudioSettingsButton"),
+    colourSettingsButton ("ColourSettingsButton"),
+    miscSettingsButton ("MiscSettingsButton"),
+    codeRepoButton ("CodeRepoButton"),
+    viewport ("AudioSettingsViewport")
 {
     bgColour = CabbageSettings::getColourFromValueTree (settings.getValueTree(), CabbageColourIds::menuBarBackground, Colour (147, 210, 0));
     labelBgColour = bgColour.contrasting(0.05f);
     labelTextColour = labelBgColour.contrasting(0.85f);
-    propertyPanelLook = new PropertyPanelLookAndFeel();
+    propertyPanelLook.reset (new PropertyPanelLookAndFeel());
     propertyPanelLook->setColours(bgColour, labelBgColour, labelTextColour);
-    miscPanel.setLookAndFeel(propertyPanelLook);
-    colourPanel.setLookAndFeel(propertyPanelLook);
+    miscPanel.setLookAndFeel(propertyPanelLook.get());
+    colourPanel.setLookAndFeel(propertyPanelLook.get());
     audioDeviceSelector->getLookAndFeel().setColour(Label::ColourIds::textColourId, labelTextColour);
     audioDeviceSelector->getLookAndFeel().setColour(ListBox::ColourIds::textColourId, labelTextColour);
     audioDeviceSelector->getLookAndFeel().setColour(ListBox::ColourIds::outlineColourId, labelBgColour.contrasting(0.5f));
@@ -74,7 +74,8 @@ CabbageSettingsWindow::CabbageSettingsWindow (CabbageSettings& settings, AudioDe
     miscPanel.setVisible (false);
     addAndMakeVisible (listBox);
     listBox.setVisible (false);
-    addAndMakeVisible (codeEditor = new CodeEditorComponent (document, &csoundTokeniser));
+    codeEditor.reset (new CodeEditorComponent (document, &csoundTokeniser));
+    addAndMakeVisible (codeEditor.get());
     codeEditor->setVisible (false);
     listBox.getLookAndFeel().setColour (ListBox::backgroundColourId, Colours::transparentWhite);
     updateColourScheme();
@@ -86,7 +87,7 @@ CabbageSettingsWindow::CabbageSettingsWindow (CabbageSettings& settings, AudioDe
     addAndMakeVisible (miscSettingsButton);
     addAndMakeVisible (colourSettingsButton);
     addAndMakeVisible (codeRepoButton);
-    viewport.setViewedComponent (audioDeviceSelector, false);
+    viewport.setViewedComponent (audioDeviceSelector.get(), false);
 
     audioDeviceSelector->setVisible (true);
     viewport.setScrollBarsShown (true, false);
@@ -156,7 +157,7 @@ CabbageSettingsWindow::RepoListBox::RepoListBox (CabbageSettingsWindow* _owner):
 
     StringArray customCodeSnippets;
     std::unique_ptr<XmlElement> repoXml;
-    XmlElement* newEntryXml, *newEntryXml1;
+    // XmlElement* newEntryXml, *newEntryXml1;
 
     repoXml = owner->settings.getUserSettings()->getXmlValue ("CopeRepoXmlData");
 
@@ -208,7 +209,7 @@ void CabbageSettingsWindow::RepoListBox::listBoxItemClicked (int row, const Mous
 void CabbageSettingsWindow::RepoListBox::updateEntry (String updatedCode)
 {
     std::unique_ptr<XmlElement> repoXml;
-    XmlElement* newEntryXml, *newEntryXml1;
+    // XmlElement* newEntryXml, *newEntryXml1;
     repoXml = owner->settings.getUserSettings()->getXmlValue ("CopeRepoXmlData");
 
     if (!repoXml)
@@ -222,7 +223,7 @@ void CabbageSettingsWindow::RepoListBox::updateEntry (String updatedCode)
 void CabbageSettingsWindow::RepoListBox::removeEntry()
 {
     std::unique_ptr<XmlElement> repoXml;
-    XmlElement* newEntryXml, *newEntryXml1;
+    // XmlElement* newEntryXml, *newEntryXml1;
     repoXml = owner->settings.getUserSettings()->getXmlValue ("CopeRepoXmlData");
 
     if (!repoXml)

--- a/Source/Settings/CabbageSettingsWindow.h
+++ b/Source/Settings/CabbageSettingsWindow.h
@@ -104,7 +104,7 @@ public:
     };
 
     RepoListBox listBox;
-    ScopedPointer<CodeEditorComponent> codeEditor;
+    std::unique_ptr<CodeEditorComponent> codeEditor;
     CodeDocument document;
     CsoundTokeniser csoundTokeniser;
 
@@ -134,11 +134,11 @@ public:
 
 private:
     PropertyPanel colourPanel, miscPanel;
-    ScopedPointer<PropertyPanelLookAndFeel> propertyPanelLook;
+    std::unique_ptr<PropertyPanelLookAndFeel> propertyPanelLook;
 
     Colour bgColour, labelBgColour, labelTextColour;
 
-    ScopedPointer<AudioDeviceSelectorComponent> audioDeviceSelector;
+    std::unique_ptr<AudioDeviceSelectorComponent> audioDeviceSelector;
     ValueTree valueTree;
     TextButton deleteRepoButton, saveRepoButton;
     ImageButton audioSettingsButton, colourSettingsButton, miscSettingsButton, codeRepoButton;

--- a/Source/StandaloneLite/StandaloneFilterApp.cpp
+++ b/Source/StandaloneLite/StandaloneFilterApp.cpp
@@ -45,7 +45,7 @@ public:
 #endif
                                            );
 #else
-        ScopedPointer<AudioDeviceManager::AudioDeviceSetup> setup = new AudioDeviceManager::AudioDeviceSetup();
+        std::unique_ptr<AudioDeviceManager::AudioDeviceSetup> setup (new AudioDeviceManager::AudioDeviceSetup());
         setup->sampleRate = 44100;
         setup->outputDeviceName = "ASIO4ALL v2";
         setup->inputDeviceName = "ASIO4ALL v2";
@@ -53,7 +53,7 @@ public:
         return new StandaloneFilterWindow (getApplicationName(),  getCommandLineParameters(),
                                            LookAndFeel::getDefaultLookAndFeel().findColour (ResizableWindow::backgroundColourId),
                                            appProperties.getUserSettings(),
-                                           false, "ASIO4ALL v2", setup
+                                           false, "ASIO4ALL v2", setup.get()
 #ifdef JucePlugin_PreferredChannelConfigurations
                                            , juce::Array<StandalonePluginHolder::PluginInOuts> (channels, juce::numElementsInArray (channels))
 #endif
@@ -64,7 +64,7 @@ public:
     //==============================================================================
     void initialise (const String&) override
     {
-        mainWindow = createWindow();
+        mainWindow.reset (createWindow());
 
 #if JUCE_IOS || JUCE_ANDROID
         Desktop::getInstance().setKioskModeComponent (mainWindow, false);
@@ -87,7 +87,7 @@ public:
 
 protected:
     ApplicationProperties appProperties;
-    ScopedPointer<StandaloneFilterWindow> mainWindow;
+    std::unique_ptr<StandaloneFilterWindow> mainWindow;
 };
 
 #if JucePlugin_Build_Standalone && JUCE_IOS

--- a/Source/StandaloneLite/StandaloneFilterWindow.h
+++ b/Source/StandaloneLite/StandaloneFilterWindow.h
@@ -138,9 +138,9 @@ public:
         }
         
             
-        pluginHolder = new StandalonePluginHolder (settingsToUse, takeOwnershipOfSettings,
-                                                   preferredDefaultDeviceName, preferredSetupOptions,
-                                                   constrainToConfiguration);
+        pluginHolder.reset (new StandalonePluginHolder (settingsToUse, takeOwnershipOfSettings,
+                                                        preferredDefaultDeviceName, preferredSetupOptions,
+                                                        constrainToConfiguration));
         setName ("CabbageLite");
         setAlwaysOnTop (true);
 #if JUCE_IOS || JUCE_ANDROID
@@ -173,7 +173,7 @@ public:
         startTimer (200);
 
         CabbageIDELookAndFeel lAndF;
-        outputConsole = new CsoundOutputWindow();
+        outputConsole.reset (new CsoundOutputWindow());
         outputConsole->getEditor().setFont(Font(14, 1));
 		if (commandLineParams.isNotEmpty())
         {
@@ -304,7 +304,7 @@ public:
     }
 
     //==============================================================================
-    AudioProcessor* getAudioProcessor() const noexcept      { return pluginHolder->processor; }
+    AudioProcessor* getAudioProcessor() const noexcept      { return pluginHolder->processor.get(); }
     AudioDeviceManager& getDeviceManager() const noexcept   { return pluginHolder->deviceManager; }
 
     /** Deletes and re-creates the plugin, resetting it to its default state. */
@@ -472,9 +472,9 @@ public:
         optionsButton.setBounds (8, 6, 60, getTitleBarHeight() - 8);
     }
 
-    virtual StandalonePluginHolder* getPluginHolder()    { return pluginHolder; }
+    virtual StandalonePluginHolder* getPluginHolder()    { return pluginHolder.get(); }
 
-    ScopedPointer<StandalonePluginHolder> pluginHolder;
+    std::unique_ptr<StandalonePluginHolder> pluginHolder;
 
 private:
     //==============================================================================
@@ -495,7 +495,7 @@ private:
                 editor->addComponentListener (this);
                 componentMovedOrResized (*editor, false, true);
 
-                addAndMakeVisible (editor);
+                addAndMakeVisible (editor.get());
             }
 
             addChildComponent (notification);
@@ -514,7 +514,7 @@ private:
             if (editor != nullptr)
             {
                 editor->removeComponentListener (this);
-                owner.pluginHolder->processor->editorBeingDeleted (editor);
+                owner.pluginHolder->processor->editorBeingDeleted (editor.get());
                 editor = nullptr;
             }
         }
@@ -616,7 +616,7 @@ private:
         //==============================================================================
         StandaloneFilterWindow& owner;
         NotificationArea notification;
-        ScopedPointer<AudioProcessorEditor> editor;
+        std::unique_ptr<AudioProcessorEditor> editor;
         bool shouldShowNotification;
 
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (MainContentComponent)
@@ -626,7 +626,7 @@ private:
     TextButton optionsButton;
     File csdFile;
     int64 lastModified;
-    ScopedPointer<CsoundOutputWindow> outputConsole;
+    std::unique_ptr<CsoundOutputWindow> outputConsole;
     bool cabbageFiledOpened = false;
     String csoundOutput;
     PluginExporter pluginExporter;

--- a/Source/Widgets/Legacy/Soundfiler.cpp
+++ b/Source/Widgets/Legacy/Soundfiler.cpp
@@ -72,18 +72,21 @@ Soundfiler::Soundfiler (int sr, Colour col, Colour bgcol):
     drawWaveform (false)
 {
     formatManager.registerBasicFormats();
-    thumbnail = new AudioThumbnail (2, formatManager, thumbnailCache);
+    thumbnail.reset (new AudioThumbnail (2, formatManager, thumbnailCache));
     thumbnail->addChangeListener (this);
     //setSize(400, 200);
     sampleRate = sr;
-    addAndMakeVisible (scrollbar = new ScrollBar (false));
+    scrollbar.reset (new ScrollBar (false));
+    addAndMakeVisible (scrollbar.get());
     scrollbar->setRangeLimits (visibleRange);
     //scrollbar->setAutoHide (false);
     scrollbar->addListener (this);
     currentPositionMarker->setFill (Colours::white.withAlpha (0.85f));
-    addAndMakeVisible (currentPositionMarker);
-    addAndMakeVisible (zoomIn = new ZoomButton ("zoomIn"));
-    addAndMakeVisible (zoomOut = new ZoomButton ("zoomOut"));
+    addAndMakeVisible (currentPositionMarker.get());
+    zoomIn.reset (new ZoomButton ("zoomIn"));
+    addAndMakeVisible (zoomIn.get());
+    zoomOut.reset (new ZoomButton ("zoomOut"));
+    addAndMakeVisible (zoomOut.get());
     zoomIn->addChangeListener (this);
     zoomOut->addChangeListener (this);
 }
@@ -120,7 +123,7 @@ void Soundfiler::resized()
 //==============================================================================
 void Soundfiler::scrollBarMoved (ScrollBar* scrollBarThatHasMoved, double newRangeStart)
 {
-    if (scrollBarThatHasMoved == scrollbar)
+    if (scrollBarThatHasMoved == scrollbar.get())
         setRange (visibleRange.movedToStartAt (newRangeStart));
 }
 

--- a/Source/Widgets/Legacy/Soundfiler.h
+++ b/Source/Widgets/Legacy/Soundfiler.h
@@ -97,8 +97,8 @@ private:
     int imgCount;
     Range<double> visibleRange;
     double zoom;
-    ScopedPointer<DrawableRectangle> currentPositionMarker;
-    ScopedPointer<ScrollBar> scrollbar;
+    std::unique_ptr<DrawableRectangle> currentPositionMarker;
+    std::unique_ptr<ScrollBar> scrollbar;
     void setRange (Range<double> newRange);
     void resized() override;
     void paint (Graphics& g) override;
@@ -111,14 +111,14 @@ private:
     double scrubberPosition;
     void scrollBarMoved (ScrollBar* scrollBarThatHasMoved, double newRangeStart) override;
     void changeListenerCallback (ChangeBroadcaster* source) override;
-    ScopedPointer<ZoomButton> zoomIn, zoomOut;
+    std::unique_ptr<ZoomButton> zoomIn, zoomOut;
 
     AudioFormatManager formatManager;
     float sampleRate;
     float regionWidth;
     Image waveformImage;
     AudioThumbnailCache thumbnailCache;
-    ScopedPointer<AudioThumbnail> thumbnail;
+    std::unique_ptr<AudioThumbnail> thumbnail;
     Colour colour, bgColour;
     int mouseDownX, mouseUpX;
     Rectangle<int> localBounds;

--- a/Source/Widgets/Legacy/TableManager.cpp
+++ b/Source/Widgets/Legacy/TableManager.cpp
@@ -23,11 +23,14 @@
 // Class to hold all tables
 //==============================================================================
 TableManager::TableManager(): Component(), zoom (0.0), largestTable (0), scrubberPosition (0),
-    scrubberFreq (0), shouldShowTableButtons (true), shouldShowZoomButtons (true), tableIndex (0),
-    mainFooterHeight (25), backgroundColour (CabbageUtilities::getDarkerBackgroundSkin()), scrollbarEnabled (true)
+    scrubberFreq (0), shouldShowTableButtons (true), shouldShowZoomButtons (true),
+    mainFooterHeight (25), backgroundColour (CabbageUtilities::getDarkerBackgroundSkin()),
+    tableIndex (0), scrollbarEnabled (true)
 {
-    addAndMakeVisible (zoomIn = new RoundButton ("zoomIn", Colours::white));
-    addAndMakeVisible (zoomOut = new RoundButton ("zoomOut", Colours::white));
+    zoomIn.reset (new RoundButton ("zoomIn", Colours::white));
+    addAndMakeVisible (zoomIn.get());
+    zoomOut.reset (new RoundButton ("zoomOut", Colours::white));
+    addAndMakeVisible (zoomOut.get());
     //setOpaque(true);
     zoomIn->toFront (false);
     zoomIn->addChangeListener (this);
@@ -548,41 +551,43 @@ void TableManager::bringTableToFront (int ftNumber)
 //==============================================================================
 // GenTable display  component
 //==============================================================================
-GenTable::GenTable():   thumbnailCache (5),
-    currentPlayPosition (0),
-    mouseDownX (0),
-    mouseUpX (0),
-    drawWaveform (false),
-    regionWidth (1),
-    loopLength (0),
-    scrubberPosition (0),
-    currentPositionMarker (new DrawableRectangle()),
-    genRoutine (0),
-    zoom (0.0),
-    currentWidth (0),
-    normalised (0),
+GenTable::GenTable():
     tableNumber (-1),
-    showScroll (true),
-    shouldScroll (true),
+    genRoutine (0),
+    drawGrid (false),
     mainFooterHeight (25),
     paintFooterHeight (15),
-    quantiseSpace (0.01),
-    qsteps (0),
-    drawAsVUMeter (false),
     zoomButtonsOffset (10),
-    drawGrid (false),
+    quantiseSpace (0.01),
+    drawAsVUMeter (false),
     shouldFill (true),
+    shouldScroll (true),
+    normalised (0),
+    currentWidth (0),
+    zoom (0.0),
+    showScroll (true),
+    qsteps (0),
+    currentPositionMarker (new DrawableRectangle()),
+    scrubberPosition (0),
+    regionWidth (1),
+    thumbnailCache (5),
+    mouseDownX (0),
+    mouseUpX (0),
+    loopLength (0),
+    currentPlayPosition (0),
+    drawWaveform (false),
     vuGradient (Colours::yellow, 0.f, 0.f, Colours::red, getWidth(), getHeight(), false)
 {
     thumbnail = nullptr;
-    addAndMakeVisible (scrollbar = new ScrollBar (false));
+    scrollbar.reset (new ScrollBar (false));
+    addAndMakeVisible (scrollbar.get());
     scrollbar->setRangeLimits (visibleRange);
     scrollbar->setAutoHide (false);
     scrollbar->addListener (this);
-    addAndMakeVisible (currentPositionMarker);
+    addAndMakeVisible (currentPositionMarker.get());
 
-    handleViewer = new HandleViewer();
-    addAndMakeVisible (handleViewer);
+    handleViewer.reset (new HandleViewer());
+    addAndMakeVisible (handleViewer.get());
 
     minMax.setStart (0);
     minMax.setEnd (0);
@@ -615,7 +620,7 @@ void GenTable::addTable (int sr, const Colour col, int igen, var ampRange)
     if (genRoutine == 1)
     {
         formatManager.registerBasicFormats();
-        thumbnail = new AudioThumbnail (2, formatManager, thumbnailCache);
+        thumbnail.reset (new AudioThumbnail (2, formatManager, thumbnailCache));
         thumbnail->addChangeListener (this);
         setZoomFactor (0.0);
     }
@@ -876,7 +881,7 @@ void GenTable::enableEditMode (StringArray m_pFields)
         if (genRoutine == 7 || genRoutine == 5)
         {
             float pFieldAmpValue = (normalised < 0 ? pFields[5].getFloatValue() : pFields[5].getFloatValue() / pFieldMinMax.getEnd());
-            const float amp = ampToPixel (thumbHeight, minMax, pFieldAmpValue);
+            // const float amp = ampToPixel (thumbHeight, minMax, pFieldAmpValue);
             handleViewer->addHandle (0, ampToPixel (thumbHeight, minMax, pFieldAmpValue), (width > 10 ? width : 15), (width > 10 ? 5 : 15), this->tableColour);
 
             for (int i = 6; i < pFields.size(); i += 2)
@@ -1590,7 +1595,7 @@ void HandleViewer::removeHandle (HandleComponent* thisHandle)
 }
 //==================================================================================
 HandleComponent::HandleComponent (double xPos, double yPos, int _index, bool fixed, int gen, Colour _colour):
-    index (_index), x (0), y (0), colour (_colour), fixed (fixed), status (false)
+    index (_index), x (0), y (0), status (false), colour (_colour), fixed (fixed)
 {
     //our main handle object. xPos and xPos are always between 0 and 1
     //we convert them to pixel positions later, based on the size of the handleViewer

--- a/Source/Widgets/Legacy/TableManager.h
+++ b/Source/Widgets/Legacy/TableManager.h
@@ -68,7 +68,7 @@ public:
     void timerCallback();
     void updateScrollbars();
     void setRange (double start, double end);
-    ScopedPointer<DrawableRectangle> currentPositionMarker;
+    std::unique_ptr<DrawableRectangle> currentPositionMarker;
     double getLengthInSamples();
     void setScrubberPos (double pos, int tableNum);
     void scroll (double newRangeStart);
@@ -79,7 +79,7 @@ public:
     void setFile (const File file);
     void enableEditMode (StringArray pFields, int ftnumber);
     void toggleEditMode (bool enable);
-    ScopedPointer<RoundButton> zoomIn, zoomOut;
+    std::unique_ptr<RoundButton> zoomIn, zoomOut;
     OwnedArray<RoundButton> tableButtons;
     OwnedArray<GenTable> tables;
     void showZoomButtons (bool show);
@@ -151,7 +151,7 @@ public:
     void setRange (Range<double> newRange, bool isScrolling = false);
     Range<double> globalRange;
     bool isTableOnTop;
-    ScopedPointer<ScrollBar> scrollbar;
+    std::unique_ptr<ScrollBar> scrollbar;
     void resized() override;
     Range<double> visibleRange;
     bool drawGrid;
@@ -161,7 +161,7 @@ public:
 
     HandleViewer* getHandleViewer()
     {
-        return handleViewer;
+        return handleViewer.get();
     }
 
     double quantiseSpace;
@@ -242,7 +242,7 @@ private:
     double numPixelsPerIndex;
     ColourGradient gradient;
     StringArray pFields;
-    ScopedPointer<DrawableRectangle> currentPositionMarker;
+    std::unique_ptr<DrawableRectangle> currentPositionMarker;
     juce::Rectangle<int> thumbArea;
     juce::Rectangle<int> handleViewerRect;
     void paint (Graphics& g)  override;
@@ -255,13 +255,13 @@ private:
     double scrubberPosition;
     void scrollBarMoved (ScrollBar* scrollBarThatHasMoved, double newRangeStart) override;
     void changeListenerCallback (ChangeBroadcaster* source) override;
-    ScopedPointer<HandleViewer> handleViewer;
+    std::unique_ptr<HandleViewer> handleViewer;
     AudioFormatManager formatManager;
     double sampleRate;
     float regionWidth;
     Image waveformImage;
     AudioThumbnailCache thumbnailCache;
-    ScopedPointer<AudioThumbnail> thumbnail;
+    std::unique_ptr<AudioThumbnail> thumbnail;
     Colour tableColour, fontcolour;
     int mouseDownX, mouseUpX;
     juce::Rectangle<int> localBounds;
@@ -304,8 +304,8 @@ class HandleViewer : public Component
 public:
     HandleViewer();
     ~HandleViewer();
-    ScopedPointer<TextButton> button1;
-    ScopedPointer<TextButton> button2;
+    std::unique_ptr<TextButton> button1;
+    std::unique_ptr<TextButton> button2;
     void mouseDown (const MouseEvent& e);
     void mouseDrag (const MouseEvent& e);
     void positionHandle (const MouseEvent& e);


### PR DESCRIPTION
It's my unique_ptr conversion branch. Not all there is in the deprecation department, but a good deal of it.

There are also some reordering of initializers (-Wreorder)

For at aleast one case, I have converted it to an ordinary pointer.
It's objects used with `setContentOwned`, and because their lifetime will be managed by their owner, I don't think they must be held by automatic pointers.

A thing I noticed is a segfault when closing CabbageLite, which I don't know if it's my fault or not, I was going to debug it.