### PR TITLE
Use angle brackets for JuceHeader.h includes instead of quoted relative paths

### DIFF
--- a/Source/Application/CabbageDocumentWindow.h
+++ b/Source/Application/CabbageDocumentWindow.h
@@ -20,7 +20,7 @@
 #ifndef CABBAGEMAINWINDOW_H_INCLUDED
 #define CABBAGEMAINWINDOW_H_INCLUDED
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include "../CodeEditor/CabbageEditorContainer.h"
 #include "../BinaryData/CabbageBinaryData.h"
 #include "../GUIEditor/CabbagePropertiesPanel.h"

--- a/Source/Application/CabbageDocumentWindow.h
+++ b/Source/Application/CabbageDocumentWindow.h
@@ -20,7 +20,7 @@
 #ifndef CABBAGEMAINWINDOW_H_INCLUDED
 #define CABBAGEMAINWINDOW_H_INCLUDED
 
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "../CodeEditor/CabbageEditorContainer.h"
 #include "../BinaryData/CabbageBinaryData.h"
 #include "../GUIEditor/CabbagePropertiesPanel.h"

--- a/Source/Application/CabbageMainComponent.h
+++ b/Source/Application/CabbageMainComponent.h
@@ -21,7 +21,7 @@
 #define CABBAGECONTENT_H_INCLUDED
 
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include "../CodeEditor/CabbageEditorContainer.h"
 #include "../BinaryData/CabbageBinaryData.h"
 #include "../GUIEditor/CabbagePropertiesPanel.h"

--- a/Source/Application/CabbageMainComponent.h
+++ b/Source/Application/CabbageMainComponent.h
@@ -21,7 +21,7 @@
 #define CABBAGECONTENT_H_INCLUDED
 
 
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "../CodeEditor/CabbageEditorContainer.h"
 #include "../BinaryData/CabbageBinaryData.h"
 #include "../GUIEditor/CabbagePropertiesPanel.h"

--- a/Source/Application/FileTab.h
+++ b/Source/Application/FileTab.h
@@ -18,7 +18,7 @@
 */
 
 #pragma once
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include "../Utilities/CabbageUtilities.h"
 
 

--- a/Source/Application/FileTab.h
+++ b/Source/Application/FileTab.h
@@ -18,7 +18,7 @@
 */
 
 #pragma once
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "../Utilities/CabbageUtilities.h"
 
 

--- a/Source/Audio/Filters/FilterGraph.cpp
+++ b/Source/Audio/Filters/FilterGraph.cpp
@@ -24,7 +24,7 @@
   ==============================================================================
 */
 
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 //#include "../UI/MainHostWindow.h"
 #include "FilterGraph.h"
 #include "InternalFilters.h"

--- a/Source/Audio/Filters/FilterGraph.cpp
+++ b/Source/Audio/Filters/FilterGraph.cpp
@@ -24,7 +24,7 @@
   ==============================================================================
 */
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 //#include "../UI/MainHostWindow.h"
 #include "FilterGraph.h"
 #include "InternalFilters.h"

--- a/Source/Audio/Filters/FilterIOConfiguration.cpp
+++ b/Source/Audio/Filters/FilterIOConfiguration.cpp
@@ -24,7 +24,7 @@
   ==============================================================================
 */
 
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "../UI/GraphEditorPanel.h"
 #include "InternalFilters.h"
 //#include "../UI/MainHostWindow.h"

--- a/Source/Audio/Filters/FilterIOConfiguration.cpp
+++ b/Source/Audio/Filters/FilterIOConfiguration.cpp
@@ -24,7 +24,7 @@
   ==============================================================================
 */
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include "../UI/GraphEditorPanel.h"
 #include "InternalFilters.h"
 //#include "../UI/MainHostWindow.h"

--- a/Source/Audio/Filters/InternalFilters.cpp
+++ b/Source/Audio/Filters/InternalFilters.cpp
@@ -24,7 +24,7 @@
   ==============================================================================
 */
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include "InternalFilters.h"
 #include "FilterGraph.h"
 

--- a/Source/Audio/Filters/InternalFilters.cpp
+++ b/Source/Audio/Filters/InternalFilters.cpp
@@ -24,7 +24,7 @@
   ==============================================================================
 */
 
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "InternalFilters.h"
 #include "FilterGraph.h"
 

--- a/Source/Audio/Plugins/CabbageInternalPluginFormat.h
+++ b/Source/Audio/Plugins/CabbageInternalPluginFormat.h
@@ -9,7 +9,7 @@
 */
 
 #pragma once
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 
 
 #include "CsoundPluginEditor.h"

--- a/Source/Audio/Plugins/CabbageInternalPluginFormat.h
+++ b/Source/Audio/Plugins/CabbageInternalPluginFormat.h
@@ -9,7 +9,7 @@
 */
 
 #pragma once
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 
 
 #include "CsoundPluginEditor.h"

--- a/Source/Audio/Plugins/CabbageMessageSystem.h
+++ b/Source/Audio/Plugins/CabbageMessageSystem.h
@@ -21,7 +21,7 @@
 #ifndef CABBMESS_H
 #define CABBMESS_H
 
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "../../CabbageCommonHeaders.h"
 
 //simple channel message classe

--- a/Source/Audio/Plugins/CabbageMessageSystem.h
+++ b/Source/Audio/Plugins/CabbageMessageSystem.h
@@ -21,7 +21,7 @@
 #ifndef CABBMESS_H
 #define CABBMESS_H
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include "../../CabbageCommonHeaders.h"
 
 //simple channel message classe

--- a/Source/Audio/Plugins/CabbagePluginEditor.h
+++ b/Source/Audio/Plugins/CabbagePluginEditor.h
@@ -20,7 +20,7 @@
 #ifndef CABBAGEPLUGINEDITOR_H_INCLUDED
 #define CABBAGEPLUGINEDITOR_H_INCLUDED
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include "CabbagePluginProcessor.h"
 
 #ifdef Cabbage_IDE_Build

--- a/Source/Audio/Plugins/CabbagePluginEditor.h
+++ b/Source/Audio/Plugins/CabbagePluginEditor.h
@@ -20,7 +20,7 @@
 #ifndef CABBAGEPLUGINEDITOR_H_INCLUDED
 #define CABBAGEPLUGINEDITOR_H_INCLUDED
 
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "CabbagePluginProcessor.h"
 
 #ifdef Cabbage_IDE_Build

--- a/Source/Audio/Plugins/CsoundPluginEditor.h
+++ b/Source/Audio/Plugins/CsoundPluginEditor.h
@@ -20,7 +20,7 @@
 #ifndef PLUGINEDITOR_H_INCLUDED
 #define PLUGINEDITOR_H_INCLUDED
 
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "CsoundPluginProcessor.h"
 
 

--- a/Source/Audio/Plugins/CsoundPluginEditor.h
+++ b/Source/Audio/Plugins/CsoundPluginEditor.h
@@ -20,7 +20,7 @@
 #ifndef PLUGINEDITOR_H_INCLUDED
 #define PLUGINEDITOR_H_INCLUDED
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include "CsoundPluginProcessor.h"
 
 

--- a/Source/Audio/Plugins/CsoundPluginProcessor.h
+++ b/Source/Audio/Plugins/CsoundPluginProcessor.h
@@ -20,7 +20,7 @@
 #ifndef PLUGINPROCESSOR_H_INCLUDED
 #define PLUGINPROCESSOR_H_INCLUDED
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include <csound.hpp>
 #include <csdebug.h>
 #include "csdl.h"

--- a/Source/Audio/Plugins/CsoundPluginProcessor.h
+++ b/Source/Audio/Plugins/CsoundPluginProcessor.h
@@ -20,7 +20,7 @@
 #ifndef PLUGINPROCESSOR_H_INCLUDED
 #define PLUGINPROCESSOR_H_INCLUDED
 
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include <csound.hpp>
 #include <csdebug.h>
 #include "csdl.h"

--- a/Source/Audio/Plugins/GenericCabbageEditor.h
+++ b/Source/Audio/Plugins/GenericCabbageEditor.h
@@ -23,7 +23,7 @@
  ==============================================================================
  */
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include "../../LookAndFeel/CabbageGenericPluginLookAndFeel.h"
 
 class GenericCabbagePluginProcessor;

--- a/Source/Audio/Plugins/GenericCabbageEditor.h
+++ b/Source/Audio/Plugins/GenericCabbageEditor.h
@@ -23,7 +23,7 @@
  ==============================================================================
  */
 
-#include "../../../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "../../LookAndFeel/CabbageGenericPluginLookAndFeel.h"
 
 class GenericCabbagePluginProcessor;

--- a/Source/Audio/UI/CabbageTransportComponent.h
+++ b/Source/Audio/UI/CabbageTransportComponent.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include "../../CabbageCommonHeaders.h"
 #include "GraphEditorPanel.h"
 

--- a/Source/Audio/UI/CabbageTransportComponent.h
+++ b/Source/Audio/UI/CabbageTransportComponent.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include "../../../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "../../CabbageCommonHeaders.h"
 #include "GraphEditorPanel.h"
 

--- a/Source/Audio/UI/GraphEditorPanel.cpp
+++ b/Source/Audio/UI/GraphEditorPanel.cpp
@@ -24,7 +24,7 @@
  ==============================================================================
  */
 
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "GraphEditorPanel.h"
 #include "../Filters/InternalFilters.h"
 #include "CabbageTransportComponent.h"

--- a/Source/Audio/UI/GraphEditorPanel.cpp
+++ b/Source/Audio/UI/GraphEditorPanel.cpp
@@ -24,7 +24,7 @@
  ==============================================================================
  */
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include "GraphEditorPanel.h"
 #include "../Filters/InternalFilters.h"
 #include "CabbageTransportComponent.h"

--- a/Source/Audio/UI/IOConfigurationWindow.cpp
+++ b/Source/Audio/UI/IOConfigurationWindow.cpp
@@ -24,7 +24,7 @@
   ==============================================================================
 */
 
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "../UI/GraphEditorPanel.h"
 #include "../Filters/InternalFilters.h"
 #include "../../Application/CabbageMainComponent.h"

--- a/Source/Audio/UI/IOConfigurationWindow.cpp
+++ b/Source/Audio/UI/IOConfigurationWindow.cpp
@@ -24,7 +24,7 @@
   ==============================================================================
 */
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include "../UI/GraphEditorPanel.h"
 #include "../Filters/InternalFilters.h"
 #include "../../Application/CabbageMainComponent.h"

--- a/Source/Cabbage.cpp
+++ b/Source/Cabbage.cpp
@@ -17,7 +17,7 @@
   02111-1307 USA
 */
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include "Application/CabbageDocumentWindow.h"
 #include "Cabbage.h"
 #include "Utilities/CabbageUtilities.h"

--- a/Source/Cabbage.cpp
+++ b/Source/Cabbage.cpp
@@ -17,7 +17,7 @@
   02111-1307 USA
 */
 
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "Application/CabbageDocumentWindow.h"
 #include "Cabbage.h"
 #include "Utilities/CabbageUtilities.h"

--- a/Source/CabbageIds.h
+++ b/Source/CabbageIds.h
@@ -20,7 +20,7 @@
 #ifndef CABBAGECOMMANDIDS_H_INCLUDED
 #define CABBAGECOMMANDIDS_H_INCLUDED
 
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 
 namespace CommandIDs
 {

--- a/Source/CabbageIds.h
+++ b/Source/CabbageIds.h
@@ -20,7 +20,7 @@
 #ifndef CABBAGECOMMANDIDS_H_INCLUDED
 #define CABBAGECOMMANDIDS_H_INCLUDED
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 
 namespace CommandIDs
 {

--- a/Source/CodeEditor/CsoundTokeniser.h
+++ b/Source/CodeEditor/CsoundTokeniser.h
@@ -20,7 +20,7 @@
 #ifndef __CSOUND_TOKER__
 #define __CSOUND_TOKER__
 
-#include "../../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 
 class CsoundTokeniser : public CodeTokeniser
 {

--- a/Source/CodeEditor/CsoundTokeniser.h
+++ b/Source/CodeEditor/CsoundTokeniser.h
@@ -20,7 +20,7 @@
 #ifndef __CSOUND_TOKER__
 #define __CSOUND_TOKER__
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 
 class CsoundTokeniser : public CodeTokeniser
 {

--- a/Source/CodeEditor/JavascriptCodeTokeniser.h
+++ b/Source/CodeEditor/JavascriptCodeTokeniser.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 
 class JavascriptTokeniser   : public CodeTokeniser
 {

--- a/Source/CodeEditor/JavascriptCodeTokeniser.h
+++ b/Source/CodeEditor/JavascriptCodeTokeniser.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 
 class JavascriptTokeniser   : public CodeTokeniser
 {

--- a/Source/LookAndFeel/CabbageGenericPluginLookAndFeel.h
+++ b/Source/LookAndFeel/CabbageGenericPluginLookAndFeel.h
@@ -18,7 +18,7 @@
 */
 #pragma once
 
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "../Settings/CabbageSettings.h"
 #include "../CabbageIds.h"
 #include "../Utilities/CabbageUtilities.h"

--- a/Source/LookAndFeel/CabbageGenericPluginLookAndFeel.h
+++ b/Source/LookAndFeel/CabbageGenericPluginLookAndFeel.h
@@ -18,7 +18,7 @@
 */
 #pragma once
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include "../Settings/CabbageSettings.h"
 #include "../CabbageIds.h"
 #include "../Utilities/CabbageUtilities.h"

--- a/Source/LookAndFeel/CabbageIDELookAndFeel.h
+++ b/Source/LookAndFeel/CabbageIDELookAndFeel.h
@@ -19,7 +19,7 @@
 #ifndef CABBAGEIDELOOKANDFEEL_H_INCLUDED
 #define CABBAGEIDELOOKANDFEEL_H_INCLUDED
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include "../Settings/CabbageSettings.h"
 #include "../CabbageIds.h"
 #include "../Utilities/CabbageUtilities.h"

--- a/Source/LookAndFeel/CabbageIDELookAndFeel.h
+++ b/Source/LookAndFeel/CabbageIDELookAndFeel.h
@@ -19,7 +19,7 @@
 #ifndef CABBAGEIDELOOKANDFEEL_H_INCLUDED
 #define CABBAGEIDELOOKANDFEEL_H_INCLUDED
 
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "../Settings/CabbageSettings.h"
 #include "../CabbageIds.h"
 #include "../Utilities/CabbageUtilities.h"

--- a/Source/LookAndFeel/CabbageLookAndFeel2.h
+++ b/Source/LookAndFeel/CabbageLookAndFeel2.h
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
 #ifndef CABBAGELOOKANDFEEL2_H_INCLUDED
 #define CABBAGELOOKANDFEEL2_H_INCLUDED
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include "../CabbageCommonHeaders.h"
 
 inline std::unique_ptr<Drawable> createDrawableFromSVG (const char* data)

--- a/Source/LookAndFeel/CabbageLookAndFeel2.h
+++ b/Source/LookAndFeel/CabbageLookAndFeel2.h
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
 #ifndef CABBAGELOOKANDFEEL2_H_INCLUDED
 #define CABBAGELOOKANDFEEL2_H_INCLUDED
 
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "../CabbageCommonHeaders.h"
 
 inline std::unique_ptr<Drawable> createDrawableFromSVG (const char* data)

--- a/Source/LookAndFeel/FlatButtonLookAndFeel.h
+++ b/Source/LookAndFeel/FlatButtonLookAndFeel.h
@@ -18,7 +18,7 @@
  */
 
 #pragma once
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include "../CabbageCommonHeaders.h"
 
 class FlatButtonLookAndFeel : public LookAndFeel_V3

--- a/Source/LookAndFeel/FlatButtonLookAndFeel.h
+++ b/Source/LookAndFeel/FlatButtonLookAndFeel.h
@@ -18,7 +18,7 @@
  */
 
 #pragma once
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "../CabbageCommonHeaders.h"
 
 class FlatButtonLookAndFeel : public LookAndFeel_V3

--- a/Source/LookAndFeel/PropertyPanelLookAndFeel.h
+++ b/Source/LookAndFeel/PropertyPanelLookAndFeel.h
@@ -18,7 +18,7 @@
  */
 
 #pragma once
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "../CabbageCommonHeaders.h"
 
 class PropertyPanelLookAndFeel : public LookAndFeel_V3

--- a/Source/LookAndFeel/PropertyPanelLookAndFeel.h
+++ b/Source/LookAndFeel/PropertyPanelLookAndFeel.h
@@ -18,7 +18,7 @@
  */
 
 #pragma once
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include "../CabbageCommonHeaders.h"
 
 class PropertyPanelLookAndFeel : public LookAndFeel_V3

--- a/Source/StandaloneLite/StandaloneFilterApp.cpp
+++ b/Source/StandaloneLite/StandaloneFilterApp.cpp
@@ -1,4 +1,4 @@
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "StandaloneFilterWindow.h"
 #include "../CabbageCommonHeaders.h"
 

--- a/Source/StandaloneLite/StandaloneFilterApp.cpp
+++ b/Source/StandaloneLite/StandaloneFilterApp.cpp
@@ -1,4 +1,4 @@
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include "StandaloneFilterWindow.h"
 #include "../CabbageCommonHeaders.h"
 

--- a/Source/StandaloneLite/StandalonePluginHolder.h
+++ b/Source/StandaloneLite/StandalonePluginHolder.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../CodeEditor/CabbageOutputConsole.h"
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 
 CabbagePluginProcessor* JUCE_CALLTYPE createCabbagePluginFilter (File inputFile, int channels)
 {

--- a/Source/StandaloneLite/StandalonePluginHolder.h
+++ b/Source/StandaloneLite/StandalonePluginHolder.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../CodeEditor/CabbageOutputConsole.h"
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 
 CabbagePluginProcessor* JUCE_CALLTYPE createCabbagePluginFilter (File inputFile, int channels)
 {

--- a/Source/Utilities/CabbageUtilities.h
+++ b/Source/Utilities/CabbageUtilities.h
@@ -22,7 +22,7 @@
 
 
 
-#include "JuceHeader.h"
+#include <JuceHeader.h>
 #include "../BinaryData/CabbageBinaryData.h"
 
 #include <fstream>

--- a/Source/Utilities/CabbageUtilities.h
+++ b/Source/Utilities/CabbageUtilities.h
@@ -22,7 +22,7 @@
 
 
 
-#include "../JuceLibraryCode/JuceHeader.h"
+#include "JuceHeader.h"
 #include "../BinaryData/CabbageBinaryData.h"
 
 #include <fstream>


### PR DESCRIPTION
This is a small step toward making Cabbage easier to build.

Projucer generally assumes there will be only one .jucer file used in a project. Multiple .jucer files are not well supported. To work around this limitation I would like to move each .jucer file to its own directory. Doing this will break the current JuceHeader.h includes because they use quotes instead of brackets and they use explicit paths relative to the files in the Source directory instead of relying on the project header search paths.

This change removes the explicit relative paths from the JuceHeader.h includes and changes the quotes to brackets so the project header search path is given priority. This will make it easier to merge later changes when the .jucer file moves are done.
