### PR TITLE
Fix editor `Auto-load from disk` with multiple files/tabs open

### DIFF
--- a/Source/Application/CabbageMainComponent.cpp
+++ b/Source/Application/CabbageMainComponent.cpp
@@ -880,14 +880,16 @@ void CabbageMainComponent::timerCallback()
         }
         
         if(cabbageSettings->getUserSettings()->getIntValue("AutoReloadFromDisk")){
+            const auto originalFileIndex = getCurrentFileIndex();
             for ( int i = 0 ; i < fileTabs.size() ; i++)
             {
                 if(fileTabs[i]->lastModified != fileTabs[i]->getFile().getLastModificationTime())
                 {
-                    setCurrentCsdFile(fileTabs[i]->getFile());
+                    currentFileIndex = i;
                     saveDocument();
                 }
             }
+            currentFileIndex = originalFileIndex;
         }
     }
     


### PR DESCRIPTION
When the editor's `Auto-load from disk` setting is enabled and multiple files/tabs are open, all tabs other than the first tab are reloaded repeatedly in an endless loop instead of only reloading when their contents change. This change fixes the issue by updating the `CabbageMainComponent::currentFileIndex` member correctly before reloading each changed file instead of calling `CabbageMainComponent::setCurrentCsdFile(...)` which does not update the `currentFileIndex` member.