### PR TITLE
Free editor file/tab Csound resources before playback restarts

### DIFF
--- a/Source/Audio/Filters/FilterGraph.h
+++ b/Source/Audio/Filters/FilterGraph.h
@@ -389,6 +389,17 @@ public:
             graph.removeNode(nodeId);
 			graph.releaseResources();
 
+			// Reset Csound so the Csound resources for this plugin are released (e.g. OSC ports).
+			// 
+			// Normally this is done in the plugin processor destructor when Juce cleans up dead graph nodes, but the
+			// new plugin processor instance will start Csound before the old one is destroyed, so we need to release
+			// Csound resources here instead of waiting until later.
+			auto pluginProcessor = dynamic_cast<CsoundPluginProcessor*>(plugin->getProcessor());
+			if (pluginProcessor)
+			{
+				pluginProcessor->resetCsound();
+			}
+
 			if (auto node = graph.addNode(std::move(processor), nodeId))
 			{
 				node->properties.set("pluginFile", desc.fileOrIdentifier);


### PR DESCRIPTION
When playback on an editor file/tab is restarted, the Csound resources for the previous playback are not freed until after Csound is restarted for the new playback instance. This order of operations causes issues if the .csd being played back requires Csound to hold resources like OSC ports because the 2nd playback will fail since the first playback's Csound instance is still holding its resources.

This change fixes the issue by explicitly resetting any previous Csound instances when playback is restarted instead of waiting for the Juce framework to delete the graph node and plugin processor holding the previous Csound instance.