### PR TITLE
Fix regression causing `texteditor` widget Csound channel init failure

### DIFF
--- a/Source/Audio/Plugins/CsoundPluginProcessor.cpp
+++ b/Source/Audio/Plugins/CsoundPluginProcessor.cpp
@@ -288,6 +288,11 @@ void CsoundPluginProcessor::initAllCsoundChannels (ValueTree cabbageData)
                                                  CabbageWidgetData::getProperty(cabbageData.getChild(i), CabbageIdentifierIds::value).toString().toUTF8().getAddress());
                     }
 				}
+                else if (typeOfWidget == CabbageWidgetTypes::texteditor)
+                {
+                    csound->SetStringChannel(CabbageWidgetData::getStringProp(cabbageData.getChild(i), CabbageIdentifierIds::channel).getCharPointer(),
+                                             CabbageWidgetData::getStringProp(cabbageData.getChild(i), CabbageIdentifierIds::text).toUTF8().getAddress());
+                }
             }
 
 


### PR DESCRIPTION
Commit 772343b68551e61352f00ccf251a84cd606bcac4 causes Csound string channel initialization to get skipped for `texteditor` widgets. This change fixes the regression by adding an explicit handler for `texteditor` widgets in `CsoundPluginProcessor::initAllCsoundChannels`.