### PR TITLE
Fix host type strings in code and docs

### DIFF
--- a/Docs/markdown/macros_and_reserved_channels.md
+++ b/Docs/markdown/macros_and_reserved_channels.md
@@ -113,13 +113,13 @@ Cabbage also set the host type, which can be retrieved using the following chann
 
 **MainStage** Returns 1 if Cabbage is host is MainStage
 
+**Nuendo** Returns 1 if Cabbage is host is Nuendo
+
 **Renoise** Returns 1 if Cabbage is host is Renoise
 
-**Repear** Returns 1 if Cabbage is host is Reaper
+**Reaper** Returns 1 if Cabbage is host is Reaper
 
 **Samplitude** Returns 1 if Cabbage is host is Samplitude
-
-**Sonar** Returns 1 if Cabbage is host is Sonar
 
 **Sonar** Returns 1 if Cabbage is host is Sonar
 

--- a/Source/Audio/Plugins/CsoundPluginProcessor.cpp
+++ b/Source/Audio/Plugins/CsoundPluginProcessor.cpp
@@ -381,7 +381,7 @@ void CsoundPluginProcessor::initAllCsoundChannels (ValueTree cabbageData)
     else if (pluginType.isSonar())
         csound->SetChannel ("Sonar", 1.0);
     else if (pluginType.isNuendo())
-        csound->SetChannel ("Neuendo", 1.0);
+        csound->SetChannel ("Nuendo", 1.0);
     else if (pluginType.isReaper())
         csound->SetChannel ("Reaper", 1.0);
     else if (pluginType.isRenoise())


### PR DESCRIPTION
This change does the following:
- Adds missing "Nuendo" host type in docs.
- Fixes spelling of "Reaper" host type in docs.
- Removes duplicated "Sonar" host type in docs.
- Fixes spelling of "Nuendo" host type in code.