### PR TITLE
Fix setting of reserved Csound channels for operating system types

### DIFF
--- a/Source/Audio/Plugins/CsoundPluginProcessor.cpp
+++ b/Source/Audio/Plugins/CsoundPluginProcessor.cpp
@@ -346,8 +346,6 @@ void CsoundPluginProcessor::initAllCsoundChannels (ValueTree cabbageData)
 
     csdFilePath.setAsCurrentWorkingDirectory();
 
-    auto osType = SystemStats::getOperatingSystemType();
-    auto osName = SystemStats::getOperatingSystemName();
 	if((SystemStats::getOperatingSystemType() & SystemStats::OperatingSystemType::Linux) != 0)
     {
 		csound->SetChannel ("LINUX", 1.0);

--- a/Source/Audio/Plugins/CsoundPluginProcessor.cpp
+++ b/Source/Audio/Plugins/CsoundPluginProcessor.cpp
@@ -346,18 +346,20 @@ void CsoundPluginProcessor::initAllCsoundChannels (ValueTree cabbageData)
 
     csdFilePath.setAsCurrentWorkingDirectory();
 
-	if(SystemStats::getOperatingSystemType() == SystemStats::OperatingSystemType::Linux)
+    auto osType = SystemStats::getOperatingSystemType();
+    auto osName = SystemStats::getOperatingSystemName();
+	if((SystemStats::getOperatingSystemType() & SystemStats::OperatingSystemType::Linux) != 0)
     {
 		csound->SetChannel ("LINUX", 1.0);
         csound->SetChannel ("Linux", 1.0);
     }
-	if(SystemStats::getOperatingSystemType() == SystemStats::OperatingSystemType::MacOSX)
+	if((SystemStats::getOperatingSystemType() & SystemStats::OperatingSystemType::MacOSX) != 0)
     {
 		csound->SetChannel ("MAC", 1.0);
         csound->SetChannel ("Macos", 1.0);
         csound->SetChannel ("MACOS", 1.0);
     }
-	if(SystemStats::getOperatingSystemType() == SystemStats::OperatingSystemType::Windows)
+	if((SystemStats::getOperatingSystemType() & SystemStats::OperatingSystemType::Windows) != 0)
     {
 		csound->SetChannel ("Windows", 1.0);
         csound->SetChannel ("WINDOWS", 1.0);


### PR DESCRIPTION
The reserved Csound channels for operating system types are not getting set correctly when types reported by the Juce framework are subtypes (e.g. `MacOSX_10_14` and `Windows10` instead of the top-level `MacOSX` and `Windows` types). This change fixes the issue by covering all current and future subtypes for `Linux`, `MacOSX` and `Windows` systems.