### PR TITLE
Reload code editor content when auto-loading from disk

### DIFF
--- a/Source/Application/CabbageMainComponent.cpp
+++ b/Source/Application/CabbageMainComponent.cpp
@@ -886,6 +886,7 @@ void CabbageMainComponent::timerCallback()
                 if(fileTabs[i]->lastModified != fileTabs[i]->getFile().getLastModificationTime())
                 {
                     currentFileIndex = i;
+                    getCurrentEditorContainer()->editor->loadContent(fileTabs[i]->getFile().loadFileAsString());
                     saveDocument();
                 }
             }


### PR DESCRIPTION
When the editor's `Auto-load from disk` setting is enabled, file changes outside of Cabbage make the editor restart Csound with the updated file contents, but the editor content is not updated. This change makes the editor content update, too.