### PR TITLE
Keep file change timer running when Csound compile fails

### DIFF
--- a/Source/Application/CabbageMainComponent.cpp
+++ b/Source/Application/CabbageMainComponent.cpp
@@ -866,7 +866,6 @@ void CabbageMainComponent::timerCallback()
         if (getFilterGraph()->graph.getNodeForId (nodeId) != nullptr && getFilterGraph()->graph.getNodeForId (nodeId)->getProcessor()->isSuspended() == true)
         {
             stopCsoundForNode ("");
-            stopTimer();
         }
 
         if (getCurrentCsdFile().existsAsFile())


### PR DESCRIPTION
When Csound fails to compile a file in the editor the timer that fires the callback to look for file changes is stopped and never restarted. Users then have to toggle the file tab `Stop/Play` button twice to get auto-loading from disk working again. This change keeps the file change watcher running when Csound compile fails.