### PR TITLE
fix combobox automation bug sending value back to host

### DIFF
--- a/Source/Audio/Plugins/CabbagePluginProcessor.cpp
+++ b/Source/Audio/Plugins/CabbagePluginProcessor.cpp
@@ -1189,31 +1189,37 @@ void CabbagePluginProcessor::getChannelDataFromCsound()
 			}
 		}
 
-		if (identChannel.isNotEmpty()) {
-			const String identChannelMessage = CabbageWidgetData::getStringProp(cabbageWidgets.getChild(i),
-				CabbageIdentifierIds::identchannelmessage);
-			memset(&tmp_string[0], 0, sizeof(tmp_string));
-			getCsound()->GetStringChannel(identChannel.toUTF8(), tmp_string);
-
-			const String identifierText(tmp_string);
-			//CabbageUtilities::debug(identifierText);
-			if (identifierText.isNotEmpty() && identifierText != identChannelMessage) {
-				CabbageWidgetData::setCustomWidgetState(cabbageWidgets.getChild(i), " " + identifierText);
-
-				if (identifierText.contains("tablenumber")) //update even if table number has not changed
-					CabbageWidgetData::setProperty(cabbageWidgets.getChild(i), CabbageIdentifierIds::update, 1);
-				else if (identifierText == CabbageIdentifierIds::tofront.toString() + "()") {
-					CabbageWidgetData::setProperty(cabbageWidgets.getChild(i), CabbageIdentifierIds::tofront,
-						Random::getSystemRandom().nextInt());
-				}
-
-				getCsound()->SetChannel(identChannel.toUTF8(), (char *) "");
-
-				CabbageWidgetData::setProperty(cabbageWidgets.getChild(i), CabbageIdentifierIds::update,
-					0); //reset value for further updates
-
-			}
-		}
+        const float update = CabbageWidgetData::getProperty(cabbageWidgets.getChild(i), CabbageIdentifierIds::update);
+        bool resetUpdate = (update == 1.0f ? true : false);
+        
+        if (identChannel.isNotEmpty()) {
+            const String identChannelMessage = CabbageWidgetData::getStringProp(cabbageWidgets.getChild(i),
+                                                                                CabbageIdentifierIds::identchannelmessage);
+            memset(&tmp_string[0], 0, sizeof(tmp_string));
+            getCsound()->GetStringChannel(identChannel.toUTF8(), tmp_string);
+            
+            const String identifierText(tmp_string);
+            //CabbageUtilities::debug(identifierText);
+            if (identifierText.isNotEmpty() && identifierText != identChannelMessage) {
+                CabbageWidgetData::setCustomWidgetState(cabbageWidgets.getChild(i), " " + identifierText);
+                
+                if (identifierText.contains("tablenumber")) { //update even if table number has not changed
+                    CabbageWidgetData::setProperty(cabbageWidgets.getChild(i), CabbageIdentifierIds::update, 1);
+                    resetUpdate = false;
+                }
+                else if (identifierText == CabbageIdentifierIds::tofront.toString() + "()") {
+                    CabbageWidgetData::setProperty(cabbageWidgets.getChild(i), CabbageIdentifierIds::tofront,
+                                                   Random::getSystemRandom().nextInt());
+                }
+                
+                getCsound()->SetChannel(identChannel.toUTF8(), (char *) "");
+                
+            }
+        }
+        
+        if (resetUpdate) {
+            CabbageWidgetData::setProperty(cabbageWidgets.getChild(i), CabbageIdentifierIds::update, 0);
+        }
 	}
 }
 


### PR DESCRIPTION
This fixes a bug where comboboxes would feed received automation values back to the host, causing incorrect automation behavior.

Steps to reproduce bug:
1. Record some combobox automation in host while in Latch mode
2. Play automation back without making any changes to the combobox. The plugin will overwrite the previous values instead of just reading the values supplied by the host.