### PR TITLE
fix bug #84

### DIFF
--- a/Source/Audio/Plugins/CabbagePluginProcessor.cpp
+++ b/Source/Audio/Plugins/CabbagePluginProcessor.cpp
@@ -1190,36 +1190,44 @@ void CabbagePluginProcessor::getChannelDataFromCsound()
 			}
 		}
 
-        const float update = CabbageWidgetData::getProperty(cabbageWidgets.getChild(i), CabbageIdentifierIds::update);
-        bool resetUpdate = (update == 1.0f ? true : false);
-        
         if (identChannel.isNotEmpty()) {
             const String identChannelMessage = CabbageWidgetData::getStringProp(cabbageWidgets.getChild(i),
-                                                                                CabbageIdentifierIds::identchannelmessage);
+                CabbageIdentifierIds::identchannelmessage);
             memset(&tmp_string[0], 0, sizeof(tmp_string));
             getCsound()->GetStringChannel(identChannel.toUTF8(), tmp_string);
-            
+
             const String identifierText(tmp_string);
             //CabbageUtilities::debug(identifierText);
             if (identifierText.isNotEmpty() && identifierText != identChannelMessage) {
                 CabbageWidgetData::setCustomWidgetState(cabbageWidgets.getChild(i), " " + identifierText);
-                
-                if (identifierText.contains("tablenumber")) { //update even if table number has not changed
+
+                if (identifierText.contains("tablenumber")) //update even if table number has not changed
                     CabbageWidgetData::setProperty(cabbageWidgets.getChild(i), CabbageIdentifierIds::update, 1);
-                    resetUpdate = false;
-                }
                 else if (identifierText == CabbageIdentifierIds::tofront.toString() + "()") {
                     CabbageWidgetData::setProperty(cabbageWidgets.getChild(i), CabbageIdentifierIds::tofront,
-                                                   Random::getSystemRandom().nextInt());
+                        Random::getSystemRandom().nextInt());
                 }
-                
+
                 getCsound()->SetChannel(identChannel.toUTF8(), (char *) "");
-                
+
+                CabbageWidgetData::setProperty(cabbageWidgets.getChild(i), CabbageIdentifierIds::update,
+                    0); //reset value for further updates
+
+            }
+            else
+            {
+                float update = CabbageWidgetData::getProperty(cabbageWidgets.getChild(i), CabbageIdentifierIds::update);
+                if (update == 1.0f)
+                    CabbageWidgetData::setProperty(cabbageWidgets.getChild(i), CabbageIdentifierIds::update,
+                                                   0);
             }
         }
         
-        if (resetUpdate) {
-            CabbageWidgetData::setProperty(cabbageWidgets.getChild(i), CabbageIdentifierIds::update, 0);
+        // reset value for widgets without identchannel
+        else
+        {
+            CabbageWidgetData::setProperty(cabbageWidgets.getChild(i), CabbageIdentifierIds::update,
+                                           0);
         }
 	}
 }


### PR DESCRIPTION
This fixes the laggy GUI bug, introduced in my combobox bugfix. 

@rorywalsh I've tested that this code eliminates both bugs, but you still might want to give it a quick look. In particular, the `if (identifierText.contains("tablenumber"))` block doesn't seem necessary; in both your original code and my current fix `CabbageIdentifierIds::update` gets set to `0` at the end of that code path anyways, so that `if` block seems unnecessary.