### PR TITLE
Fix crash in editor when auto-loading from disk

### DIFF
--- a/Source/Audio/Plugins/CabbagePluginProcessor.cpp
+++ b/Source/Audio/Plugins/CabbagePluginProcessor.cpp
@@ -1101,6 +1101,9 @@ void CabbagePluginProcessor::setParametersFromXml(XmlElement *e)
 //==============================================================================
 void CabbagePluginProcessor::getChannelDataFromCsound() 
 {
+    if (!getCsound())
+        return;
+
 	for (int i = 0; i < cabbageWidgets.getNumChildren(); i++) 
 	{
 		const var chanArray = CabbageWidgetData::getProperty(cabbageWidgets.getChild(i), CabbageIdentifierIds::channel);


### PR DESCRIPTION
When auto-loading from disk `CabbagePluginProcessor::getChannelDataFromCsound()` crashes intermittently due to `getCsound()` sometimes returning a null pointer. This change avoids the crash by returning early from `CabbagePluginProcessor::getChannelDataFromCsound()` if `getCsound()` returns a null pointer.