### PR TITLE
Fix MacOS Catalina build error

### DIFF
--- a/Source/Application/CabbageMainComponent.cpp
+++ b/Source/Application/CabbageMainComponent.cpp
@@ -1071,7 +1071,7 @@ void CabbageMainComponent::showPluginListEditor()
     pluginListWindow->toFront (true);
 }
 //==============================================================================
-void CabbageMainComponent::createEditorForFilterGraphNode (Point<int> position)
+void CabbageMainComponent::createEditorForFilterGraphNode (juce::Point<int> position)
 {
 
     String pluginName = "";
@@ -1241,7 +1241,7 @@ void CabbageMainComponent::enableEditMode()
         {
             return;
 //            graphComponent->createNewPlugin(FilterGraph::getPluginDescriptor(nodeId, getCurrentCsdFile().getFullPathName()), { graphComponent->getWidth() / 2, graphComponent->getHeight() / 2 });
-//            Point<int> pos = getFilterGraph()->getPositionOfCurrentlyOpenWindow(nodeId);
+//            juce::Point<int> pos = getFilterGraph()->getPositionOfCurrentlyOpenWindow(nodeId);
 //            createEditorForFilterGraphNode(pos);
         }
 
@@ -1932,16 +1932,16 @@ void CabbageMainComponent::runCsoundForNode (String file, int fileTabIndex)
 
 			Random rand;
 			double posOffset = rand.nextDouble() * 0.2;
-			Point<double> pluginNodePos(.5+posOffset, .5+posOffset);
-			Point<int> pluginWindowPos(-1000, -1000);
+			juce::Point<double> pluginNodePos(.5+posOffset, .5+posOffset);
+			juce::Point<int> pluginWindowPos(-1000, -1000);
 
 
 			if (getFilterGraph()->graph.getNodeForId(node))
 			{
-				pluginNodePos = Point<double>(getFilterGraph()->graph.getNodeForId(node)->properties.getWithDefault("x", rand.nextDouble()),
+				pluginNodePos = juce::Point<double>(getFilterGraph()->graph.getNodeForId(node)->properties.getWithDefault("x", rand.nextDouble()),
 					getFilterGraph()->graph.getNodeForId(node)->properties.getWithDefault("y", rand.nextDouble()));
 
-				pluginWindowPos = Point<int>(getFilterGraph()->graph.getNodeForId(node)->properties.getWithDefault("PluginWindowX", rand.nextInt(Range<int>(0, 500))),
+				pluginWindowPos = juce::Point<int>(getFilterGraph()->graph.getNodeForId(node)->properties.getWithDefault("PluginWindowX", rand.nextInt(Range<int>(0, 500))),
 					getFilterGraph()->graph.getNodeForId(node)->properties.getWithDefault("PluginWindowY", rand.nextInt(Range<int>(0, 500))));
 
 			}

--- a/Source/Application/CabbageMainComponent.h
+++ b/Source/Application/CabbageMainComponent.h
@@ -76,7 +76,7 @@ public:
 	void paint(Graphics&) override;
 	void resized() override;
 	void resizeAllWindows(int height);
-	void createEditorForFilterGraphNode(Point<int> position);
+	void createEditorForFilterGraphNode(juce::Point<int> position);
 	void createFilterGraph();
 	void createCodeEditorForFile(File file);
 	void createNewProject();

--- a/Source/Audio/Filters/FilterGraph.cpp
+++ b/Source/Audio/Filters/FilterGraph.cpp
@@ -78,7 +78,7 @@ AudioProcessorGraph::Node::Ptr FilterGraph::getNodeForName (const String& name) 
     return nullptr;
 }
 
-void FilterGraph::addPlugin (const PluginDescription& desc, Point<double> pos)
+void FilterGraph::addPlugin (const PluginDescription& desc, juce::Point<double> pos)
 {
 	formatManager.createPluginInstanceAsync(desc,
 		graph.getSampleRate(),
@@ -91,7 +91,7 @@ void FilterGraph::addPlugin (const PluginDescription& desc, Point<double> pos)
 }
 
 void FilterGraph::addPluginCallback(std::unique_ptr<AudioPluginInstance> instance,
-	const String& error, Point<double> pos)
+	const String& error, juce::Point<double> pos)
 {
 	if (instance == nullptr)
 	{
@@ -115,7 +115,7 @@ void FilterGraph::addPluginCallback(std::unique_ptr<AudioPluginInstance> instanc
 	}
 }
 
-void FilterGraph::setNodePosition (NodeID nodeID, Point<double> pos)
+void FilterGraph::setNodePosition (NodeID nodeID, juce::Point<double> pos)
 {
     if (auto* n = graph.getNodeForId (nodeID))
     {
@@ -124,7 +124,7 @@ void FilterGraph::setNodePosition (NodeID nodeID, Point<double> pos)
     }
 }
 
-Point<double> FilterGraph::getNodePosition (NodeID nodeID) const
+juce::Point<double> FilterGraph::getNodePosition (NodeID nodeID) const
 {
     if (auto* n = graph.getNodeForId (nodeID))
         return { static_cast<double> (n->properties ["x"]),
@@ -409,7 +409,7 @@ void FilterGraph::createNodeFromXml(const XmlElement& xml)
 	//mod RW
 	else
 	{
-		const Point<double> pos(xml.getDoubleAttribute("x"), xml.getDoubleAttribute("y"));
+		const juce::Point<double> pos(xml.getDoubleAttribute("x"), xml.getDoubleAttribute("y"));
 		String pluginFile = currentFile.getParentDirectory().getChildFile(pd.fileOrIdentifier).getFullPathName();
         
         pd.fileOrIdentifier = pluginFile;

--- a/Source/Audio/Filters/FilterGraph.h
+++ b/Source/Audio/Filters/FilterGraph.h
@@ -54,8 +54,8 @@ public:
     //==============================================================================
     using NodeID = AudioProcessorGraph::NodeID;
 
-    void addPlugin (const PluginDescription&, Point<double>);
-	void addPluginCallback(std::unique_ptr<AudioPluginInstance>, const String& error, Point<double>);
+    void addPlugin (const PluginDescription&, juce::Point<double>);
+	void addPluginCallback(std::unique_ptr<AudioPluginInstance>, const String& error, juce::Point<double>);
 
 
 
@@ -374,7 +374,7 @@ public:
         settings = cabbageSettings;
     }
 
-	void addCabbagePlugin(const PluginDescription& desc, Point<double> pos)
+	void addCabbagePlugin(const PluginDescription& desc, juce::Point<double> pos)
 	{
 		AudioProcessorGraph::NodeID nodeId(desc.uid);
 		std::unique_ptr <AudioProcessor> processor = createCabbageProcessor(desc.fileOrIdentifier);
@@ -405,7 +405,7 @@ public:
 				node->properties.set("pluginFile", desc.fileOrIdentifier);
 				node->properties.set("pluginType", isCabbageFile == true ? "Cabbage" : "Csound");
 				node->properties.set("pluginName", getInstrumentName(File(desc.fileOrIdentifier)));
-				setNodePosition(nodeId, Point<double>(pos.x, pos.y));
+				setNodePosition(nodeId, juce::Point<double>(pos.x, pos.y));
 				node->getProcessor()->setPlayHead(graph.getPlayHead());
 				restoreConnectionsFromXml(*xml);
 				xml = nullptr;
@@ -444,12 +444,12 @@ public:
 	}
 
 
-	Point<int> getPositionOfCurrentlyOpenWindow(AudioProcessorGraph::NodeID  nodeId)
+	juce::Point<int> getPositionOfCurrentlyOpenWindow(AudioProcessorGraph::NodeID  nodeId)
 	{
 		for (auto* w : activePluginWindows)
 			return w->getPosition();
 
-		return Point<int>(-1000, -1000);
+		return juce::Point<int>(-1000, -1000);
 	}
 
 	void setDefaultConnections(AudioProcessorGraph::NodeID nodeId)
@@ -500,8 +500,8 @@ public:
 
     AudioProcessorGraph::Node::Ptr getNodeForName (const String& name) const;
 
-    void setNodePosition (NodeID, Point<double>);
-    Point<double> getNodePosition (NodeID) const;
+    void setNodePosition (NodeID, juce::Point<double>);
+    juce::Point<double> getNodePosition (NodeID) const;
 
     //==============================================================================
     void clear();
@@ -542,7 +542,7 @@ private:
 //RW
     AudioPlayHead::CurrentPositionInfo playHeadPositionInfo;
     void createNodeFromXml (const XmlElement& xml);
-    void addFilterCallback (AudioPluginInstance*, const String& error, Point<double>);
+    void addFilterCallback (AudioPluginInstance*, const String& error, juce::Point<double>);
     void changeListenerCallback (ChangeBroadcaster*) override;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (FilterGraph)

--- a/Source/Audio/Plugins/CabbagePluginEditor.cpp
+++ b/Source/Audio/Plugins/CabbagePluginEditor.cpp
@@ -206,7 +206,7 @@ void CabbagePluginEditor::setupWindow (ValueTree widgetData)
     repaint();
 }
 //======================================================================================================
-void CabbagePluginEditor::addNewWidget (String widgetType, Point<int> position, bool isCustomPlant)
+void CabbagePluginEditor::addNewWidget (String widgetType, juce::Point<int> position, bool isCustomPlant)
 {
 
     if(isCustomPlant == false)

--- a/Source/Audio/Plugins/CabbagePluginEditor.h
+++ b/Source/Audio/Plugins/CabbagePluginEditor.h
@@ -176,7 +176,7 @@ public:
 	//=============================================================================
 
     String createNewGenericNameForPresetFile();
-    void addNewWidget (String widgetType, Point<int> point, bool isPlant = false);
+    void addNewWidget (String widgetType, juce::Point<int> point, bool isPlant = false);
     //=============================================================================
     void refreshComboListBoxContents();
     void enableEditMode (bool enable);
@@ -257,7 +257,7 @@ public:
     }
     
     String changeMessage = "";
-    Point<int> customPlantPosition;
+    juce::Point<int> customPlantPosition;
 private:
 	  
     //---- main component that holds widgets -----
@@ -328,7 +328,7 @@ private:
     bool editModeEnabled = false;
     CabbagePluginProcessor& processor;
     String instrumentName;
-    Point<int> instrumentBounds;
+    juce::Point<int> instrumentBounds;
     SharedResourcePointer<TooltipWindow> tooltipWindow;
 
 

--- a/Source/Audio/UI/GraphEditorPanel.cpp
+++ b/Source/Audio/UI/GraphEditorPanel.cpp
@@ -213,7 +213,7 @@ private AudioProcessorParameter::Listener
     
     void mouseDown (const MouseEvent& e) override
     {
-        originalPos = localPointToGlobal (Point<int>());
+        originalPos = localPointToGlobal (juce::Point<int>());
         
         toFront (true);
         
@@ -360,7 +360,7 @@ private AudioProcessorParameter::Listener
         }
     }
     
-    Point<float> getPinPos (int index, bool isInput) const
+    juce::Point<float> getPinPos (int index, bool isInput) const
     {
         for (auto* pin : pins)
             if (pin->pin.channelIndex == index && isInput == pin->isInput)
@@ -550,7 +550,7 @@ private AudioProcessorParameter::Listener
     OwnedArray<PinComponent> pins;
     int numInputs = 0, numOutputs = 0;
     int pinSize = 16;
-    Point<int> originalPos;
+    juce::Point<int> originalPos;
     Font font { 13.0f, Font::bold };
     int numIns = 0, numOuts = 0;
     DropShadowEffect shadow;
@@ -585,13 +585,13 @@ public SettableTooltipClient
         }
     }
     
-    void dragStart (Point<float> pos)
+    void dragStart (juce::Point<float> pos)
     {
         lastInputPos = pos;
         resizeToFit();
     }
     
-    void dragEnd (Point<float> pos)
+    void dragEnd (juce::Point<float> pos)
     {
         lastOutputPos = pos;
         resizeToFit();
@@ -599,7 +599,7 @@ public SettableTooltipClient
     
     void update()
     {
-        Point<float> p1, p2;
+        juce::Point<float> p1, p2;
         getPoints (p1, p2);
         
         if (lastInputPos != p1 || lastOutputPos != p2)
@@ -608,7 +608,7 @@ public SettableTooltipClient
     
     void resizeToFit()
     {
-        Point<float> p1, p2;
+        juce::Point<float> p1, p2;
         getPoints (p1, p2);
         
         auto newBounds = Rectangle<float> (p1, p2).expanded (4.0f).getSmallestIntegerContainer();
@@ -621,7 +621,7 @@ public SettableTooltipClient
         repaint();
     }
     
-    void getPoints (Point<float>& p1, Point<float>& p2) const
+    void getPoints (juce::Point<float>& p1, juce::Point<float>& p2) const
     {
         p1 = lastInputPos;
         p2 = lastOutputPos;
@@ -645,7 +645,7 @@ public SettableTooltipClient
     
     bool hitTest (int x, int y) override
     {
-        auto pos = Point<int> (x, y).toFloat();
+        auto pos = juce::Point<int> (x, y).toFloat();
         
         if (hitPath.contains (pos))
         {
@@ -696,7 +696,7 @@ public SettableTooltipClient
     
     void resized() override
     {
-        Point<float> p1, p2;
+        juce::Point<float> p1, p2;
         getPoints (p1, p2);
         
         lastInputPos = p1;
@@ -733,9 +733,9 @@ public SettableTooltipClient
         linePath.setUsingNonZeroWinding (true);
     }
     
-    void getDistancesFromEnds (Point<float> p, double& distanceFromStart, double& distanceFromEnd) const
+    void getDistancesFromEnds (juce::Point<float> p, double& distanceFromStart, double& distanceFromEnd) const
     {
-        Point<float> p1, p2;
+        juce::Point<float> p1, p2;
         getPoints (p1, p2);
         
         distanceFromStart = p1.getDistanceFrom (p);
@@ -745,7 +745,7 @@ public SettableTooltipClient
     GraphEditorPanel& panel;
     FilterGraph& graph;
     AudioProcessorGraph::Connection connection { { {}, 0 }, { {}, 0 } };
-    Point<float> lastInputPos, lastOutputPos;
+    juce::Point<float> lastInputPos, lastOutputPos;
     Path linePath, hitPath;
     bool dragging = false;
     
@@ -802,7 +802,7 @@ void GraphEditorPanel::mouseDrag (const MouseEvent& e)
     //    stopTimer();
 }
 
-void GraphEditorPanel::createNewPlugin (const PluginDescription& desc, Point<double> position)
+void GraphEditorPanel::createNewPlugin (const PluginDescription& desc, juce::Point<double> position)
 {
 
     if (desc.pluginFormatName == "Cabbage")
@@ -829,7 +829,7 @@ GraphEditorPanel::ConnectorComponent* GraphEditorPanel::getComponentForConnectio
     return nullptr;
 }
 
-GraphEditorPanel::PinComponent* GraphEditorPanel::findPinAt (Point<float> pos) const
+GraphEditorPanel::PinComponent* GraphEditorPanel::findPinAt (juce::Point<float> pos) const
 {
     for (auto* fc : nodes)
     {
@@ -924,7 +924,7 @@ void GraphEditorPanel::updateComponents()
     
 }
 
-void GraphEditorPanel::showPopupMenu(Point<int> mousePos)
+void GraphEditorPanel::showPopupMenu(juce::Point<int> mousePos)
 {
     //mod RW
     if (auto* graphWindow = findParentComponentOfClass<FilterGraphDocumentWindow>())
@@ -976,7 +976,7 @@ void GraphEditorPanel::showPopupMenu(Point<int> mousePos)
         else if(r >= 20000)
         {
             auto* desc = graphWindow->getOwner()->knownPluginList.getType (graphWindow->getOwner()->knownPluginList.getIndexChosenByMenu (r));
-			const Point<double>newPos(double(mousePos.getX()) / getWidth(), double(mousePos.getY()) / getHeight());
+			const juce::Point<double>newPos(double(mousePos.getX()) / getWidth(), double(mousePos.getY()) / getHeight());
             createNewPlugin (*desc, newPos);
         }
         
@@ -1348,7 +1348,7 @@ void GraphDocumentComponent::resized()
     checkAvailableWidth();
 }
 
-void GraphDocumentComponent::createNewPlugin (const PluginDescription& desc, Point<double> pos)
+void GraphDocumentComponent::createNewPlugin (const PluginDescription& desc, juce::Point<double> pos)
 {
     graphPanel->createNewPlugin (desc, pos);
 }

--- a/Source/Audio/UI/GraphEditorPanel.h
+++ b/Source/Audio/UI/GraphEditorPanel.h
@@ -41,7 +41,7 @@ public:
     GraphEditorPanel (FilterGraph& graph);
     ~GraphEditorPanel();
     
-    void createNewPlugin (const PluginDescription&, Point<double> position);
+    void createNewPlugin (const PluginDescription&, juce::Point<double> position);
     
     void paint (Graphics&) override;
     void resized() override;
@@ -56,7 +56,7 @@ public:
     void updateComponents();
     
     //==============================================================================
-    void showPopupMenu (Point<int> position);
+    void showPopupMenu (juce::Point<int> position);
     
     //==============================================================================
     void beginConnectorDrag (AudioProcessorGraph::NodeAndChannel source,
@@ -87,10 +87,10 @@ private:
     std::unique_ptr<PopupMenu> menu;
     FilterComponent* getComponentForFilter (AudioProcessorGraph::NodeID) const;
     ConnectorComponent* getComponentForConnection (const AudioProcessorGraph::Connection&) const;
-    PinComponent* findPinAt (Point<float>) const;
+    PinComponent* findPinAt (juce::Point<float>) const;
     
     //==============================================================================
-    Point<int> originalTouchPos;
+    juce::Point<int> originalTouchPos;
     
     //void timerCallback() override;
     
@@ -117,7 +117,7 @@ public:
     ~GraphDocumentComponent();
     
     //==============================================================================
-    void createNewPlugin (const PluginDescription&, Point<double> position);
+    void createNewPlugin (const PluginDescription&, juce::Point<double> position);
     void setDoublePrecision (bool doublePrecision);
     bool closeAnyOpenPluginWindows();
     

--- a/Source/CodeEditor/CabbageCodeEditor.cpp
+++ b/Source/CodeEditor/CabbageCodeEditor.cpp
@@ -232,7 +232,7 @@ void CabbageCodeEditorComponent::timerCallback()
     if (isDebugModeEnabled() == true)
     {
         MouseInputSource mouse = Desktop::getInstance().getMainMouseSource();
-        Point<int> mousePos = getLocalPoint (nullptr, mouse.getScreenPosition()).toInt();
+        juce::Point<int> mousePos = getLocalPoint (nullptr, mouse.getScreenPosition()).toInt();
 
         CodeDocument::Position start, end;
         getDocument().findTokenContaining (getPositionAt (mousePos.x, mousePos.y), start, end);

--- a/Source/GUIEditor/ComponentLayoutEditor.h
+++ b/Source/GUIEditor/ComponentLayoutEditor.h
@@ -63,7 +63,7 @@ public:
     SelectedItemSet <ComponentOverlay*>& getLassoSelection() override;
     LassoComponent <ComponentOverlay*> lassoComp;
     SelectedComponents selectedComponents;
-    Point<int> currentMouseCoors;
+    juce::Point<int> currentMouseCoors;
     void resetAllInterest();
     CabbagePluginEditor* getPluginEditor();
 #ifndef Cabbage_Lite

--- a/Source/LookAndFeel/CabbageLookAndFeel2.cpp
+++ b/Source/LookAndFeel/CabbageLookAndFeel2.cpp
@@ -591,7 +591,7 @@ void CabbageLookAndFeel2::drawRotarySlider (Graphics& g, int x, int y, int width
         if (!useSliderSVG)
         {
             Path newPolygon;
-            Point<float> centre (centreX, centreY);
+            juce::Point<float> centre (centreX, centreY);
 
             if (diameter >= 25)   //If diameter is >= 40 then polygon has 12 steps
             {

--- a/Source/LookAndFeel/FlatButtonLookAndFeel.cpp
+++ b/Source/LookAndFeel/FlatButtonLookAndFeel.cpp
@@ -457,7 +457,7 @@ void FlatButtonLookAndFeel::drawRotarySlider (Graphics& g, int x, int y, int wid
     g.strokePath (outlineArc, PathStrokeType (slider.isEnabled() ? (isMouseOver ? 2.0f : 1.2f) : 0.3f));
         
     Path newPolygon;
-    Point<float> centre (centreX, centreY);
+    juce::Point<float> centre (centreX, centreY);
 
     if (diameter >= 25)   //If diameter is >= 40 then polygon has 12 steps
     {

--- a/Source/Utilities/CabbageFileBrowser.h
+++ b/Source/Utilities/CabbageFileBrowser.h
@@ -147,7 +147,7 @@ public:
 
     
     void mouseDrag (const MouseEvent &event) override;
-    Point<float> componentPos = {0,0};
+    juce::Point<float> componentPos = {0,0};
     String lastClickedFile = "";
     //==============================================================================
     /** This abstract base class is implemented by LookAndFeel classes to provide

--- a/Source/Widgets/CabbageEncoder.cpp
+++ b/Source/Widgets/CabbageEncoder.cpp
@@ -195,7 +195,7 @@ void CabbageEncoder::paint (Graphics& g)
         //g.drawEllipse(slider.reduced(getWidth()*.11).toFloat(), isMouseOver ? 1.5f : 1.f);
 
         Path newPolygon;
-        Point<float> centre (centreX, centreY);
+        juce::Point<float> centre (centreX, centreY);
 
         if (diameter >= 25)   //If diameter is >= 40 then polygon has 12 steps
         {

--- a/Source/Widgets/CabbageKeyboardDisplay.cpp
+++ b/Source/Widgets/CabbageKeyboardDisplay.cpp
@@ -333,13 +333,13 @@ float MidiKeyboardDisplay::getTotalKeyboardWidth() const noexcept
 	return getKeyPos(rangeEnd).getEnd();
 }
 
-int MidiKeyboardDisplay::getNoteAtPosition(Point<float> p)
+int MidiKeyboardDisplay::getNoteAtPosition(juce::Point<float> p)
 {
 	float v;
 	return xyToNote(p, v);
 }
 
-int MidiKeyboardDisplay::xyToNote(Point<float> pos, float& mousePositionVelocity)
+int MidiKeyboardDisplay::xyToNote(juce::Point<float> pos, float& mousePositionVelocity)
 {
 	if (!reallyContains(pos.toInt(), false))
 		return -1;
@@ -356,10 +356,10 @@ int MidiKeyboardDisplay::xyToNote(Point<float> pos, float& mousePositionVelocity
 			p = { getHeight() - p.x, p.y };
 	}
 
-	return remappedXYToNote(p + Point<float>(xOffset, 0), mousePositionVelocity);
+	return remappedXYToNote(p + juce::Point<float>(xOffset, 0), mousePositionVelocity);
 }
 
-int MidiKeyboardDisplay::remappedXYToNote(Point<float> pos, float& mousePositionVelocity) const
+int MidiKeyboardDisplay::remappedXYToNote(juce::Point<float> pos, float& mousePositionVelocity) const
 {
 	auto blackNoteLength = getBlackNoteLength();
 
@@ -762,7 +762,7 @@ void MidiKeyboardDisplay::updateNoteUnderMouse(const MouseEvent& e, bool isDown)
 	updateNoteUnderMouse(e.getEventRelativeTo(this).position, isDown, e.source.getIndex());
 }
 
-void MidiKeyboardDisplay::updateNoteUnderMouse(Point<float> pos, bool isDown, int fingerNum)
+void MidiKeyboardDisplay::updateNoteUnderMouse(juce::Point<float> pos, bool isDown, int fingerNum)
 {
 	float mousePositionVelocity = 0.0f;
 	auto newNote = xyToNote(pos, mousePositionVelocity);

--- a/Source/Widgets/CabbageKeyboardDisplay.h
+++ b/Source/Widgets/CabbageKeyboardDisplay.h
@@ -171,7 +171,7 @@ public:
 	float getTotalKeyboardWidth() const noexcept;
 
 	/** Returns the key at a given coordinate. */
-	int getNoteAtPosition(Point<float> position);	
+	int getNoteAtPosition(juce::Point<float> position);	
 	void setOctaveForMiddleC(int octaveNumForMiddleC);
 
 	/** This returns the value set by setOctaveForMiddleC().
@@ -309,10 +309,10 @@ private:
 	int keyMappingOctave = 6, octaveNumForMiddleC = 3;
 
 	Range<float> getKeyPos(int midiNoteNumber) const;
-	int xyToNote(Point<float>, float& mousePositionVelocity);
-	int remappedXYToNote(Point<float>, float& mousePositionVelocity) const;
+	int xyToNote(juce::Point<float>, float& mousePositionVelocity);
+	int remappedXYToNote(juce::Point<float>, float& mousePositionVelocity) const;
 	void resetAnyKeysInUse();
-	void updateNoteUnderMouse(Point<float>, bool isDown, int fingerNum);
+	void updateNoteUnderMouse(juce::Point<float>, bool isDown, int fingerNum);
 	void updateNoteUnderMouse(const MouseEvent&, bool isDown);
 	void repaintNote(int midiNoteNumber);
 	void setLowestVisibleKeyFloat(float noteNumber);

--- a/Source/Widgets/CabbageXYPad.cpp
+++ b/Source/Widgets/CabbageXYPad.cpp
@@ -44,7 +44,7 @@ CabbageXYPad::CabbageXYPad (ValueTree wData, CabbagePluginEditor* editor)
     widgetData.addListener (this);              //add listener to valueTree so it gets notified when a widget's property changes
     initialiseCommonAttributes (this, wData);   //initialise common attributes such as bounds, name, rotation, etc..
 
-    const Point<float> pos (getValueAsPosition (Point<float> (valueX, valueY)));
+    const juce::Point<float> pos (getValueAsPosition (juce::Point<float> (valueX, valueY)));
     ball.setBounds (pos.getX(), pos.getY(), 20, 20);
     ball.setInterceptsMouseClicks (false, false);
     addAndMakeVisible (ball);
@@ -97,7 +97,7 @@ CabbageXYPad::~CabbageXYPad()
 void CabbageXYPad::mouseDown (const MouseEvent& e)
 {
     owner->enableXYAutomator (getName(), false);
-    ball.setTopLeftPosition (Point<int> (e.getPosition().getX() - ball.getWidth()*.5f, e.getPosition().getY() - ball.getWidth()*.5f));
+    ball.setTopLeftPosition (juce::Point<int> (e.getPosition().getX() - ball.getWidth()*.5f, e.getPosition().getY() - ball.getWidth()*.5f));
     mouseDownXY.setXY (ball.getPosition().getX() + ball.getWidth()*.5f, ball.getPosition().getY() + ball.getHeight()*.5f);
     setPositionAsValue (ball.getPosition().toFloat());
     isAutomating = false;
@@ -125,8 +125,8 @@ void CabbageXYPad::mouseUp (const MouseEvent& e)
     {
         rightMouseButtonDown = false;
 
-        const Point<float> valueStart (getPositionAsValue (mouseDownXY));
-        const Point<float> valueEnd (getPositionAsValue (e.getPosition().toFloat()));
+        const juce::Point<float> valueStart (getPositionAsValue (mouseDownXY));
+        const juce::Point<float> valueEnd (getPositionAsValue (e.getPosition().toFloat()));
 
         dragLine = Line<float> (valueStart.getX(), valueStart.getY(), valueEnd.getX(), valueEnd.getY());
         owner->enableXYAutomator (getName(), true, dragLine);
@@ -138,7 +138,7 @@ void CabbageXYPad::changeListenerCallback (ChangeBroadcaster* source)
 {
     if (XYPadAutomator* xyAuto = dynamic_cast<XYPadAutomator*> (source))
     {
-        Point<float> pos (getValueAsPosition (Point<float> (xyAuto->getPosition().getX(), xyAuto->getPosition().getY())));
+        juce::Point<float> pos (getValueAsPosition (juce::Point<float> (xyAuto->getPosition().getX(), xyAuto->getPosition().getY())));
         pos.addXY (-ball.getWidth() / 2, -ball.getWidth() / 2);
         ball.setBounds (pos.getX(), pos.getY(), 20, 20);
 
@@ -173,7 +173,7 @@ void CabbageXYPad::valueTreePropertyChanged (ValueTree& valueTree, const Identif
 //        const float xPos = CabbageWidgetData::getNumProp (valueTree, CabbageIdentifierIds::valuex);
 //        const float yPos = CabbageWidgetData::getNumProp (valueTree, CabbageIdentifierIds::valuey);
 //        //setValues(xPos, maxY - yPos);
-//        Point<float> pos (getValueAsPosition (Point<float> (xPos, maxY - yPos)));
+//        juce::Point<float> pos (getValueAsPosition (juce::Point<float> (xPos, maxY - yPos)));
 //        //pos.addXY(-ball.getWidth() / 2, -ball.getWidth() / 2);
 //        ball.setTopLeftPosition (constrainPosition (pos.getX(), pos.getY()));
 //        repaint();
@@ -254,36 +254,36 @@ void CabbageXYPad::resized()
 }
 
 //==================================================================
-Point<int> CabbageXYPad::constrainPosition (float x, float y)
+juce::Point<int> CabbageXYPad::constrainPosition (float x, float y)
 {
     const int xPos = jlimit (xyPadRect.getX(), (xyPadRect.getWidth() + xyPadRect.getX()) - ball.getWidth(), x - ball.getWidth() / 2.f);
     const int yPos = jlimit (xyPadRect.getY(), (xyPadRect.getHeight() + xyPadRect.getY()) - ball.getHeight(), y - ball.getHeight() / 2.f);
-    return Point<int> (xPos, yPos);
+    return juce::Point<int> (xPos, yPos);
 }
 
-Point<float> CabbageXYPad::getPositionAsValue (Point<float> position)
+juce::Point<float> CabbageXYPad::getPositionAsValue (juce::Point<float> position)
 {
     const float xVal = jlimit (minX, maxX, jmap (position.getX(), xyPadRect.getX(), xyPadRect.getWidth() - ball.getWidth(), minX, maxX));
     const float yVal = jlimit (minY, maxY, jmap (position.getY(), xyPadRect.getY(), xyPadRect.getHeight() - ball.getHeight(), minY, maxY));
     setValues (xVal, yVal);
 
-    return Point<float> (xVal, yVal);
+    return juce::Point<float> (xVal, yVal);
 }
 
-void CabbageXYPad::setPositionAsValue (Point<float> position)
+void CabbageXYPad::setPositionAsValue (juce::Point<float> position)
 {
     const float xVal = jlimit (minX, maxX, jmap (position.getX(), xyPadRect.getX(), xyPadRect.getWidth() - ball.getWidth(), minX, maxX));
     const float yVal = jlimit (minY, maxY, jmap (position.getY(), xyPadRect.getY(), xyPadRect.getHeight() - ball.getHeight(), minY, maxY));
     setValues (xVal, yVal);
 }
 
-Point<float> CabbageXYPad::getValueAsPosition (Point<float> position)
+juce::Point<float> CabbageXYPad::getValueAsPosition (juce::Point<float> position)
 {
     //setValues (position.getX(), maxY - position.getY());
     const float xPos = jmap (position.getX(), minX, maxX, xyPadRect.getX() + ball.getWidth() / 2, xyPadRect.getWidth() - ball.getWidth() / 2);
     const float yPos = jmap (position.getY(), minY, maxY, xyPadRect.getY() + ball.getWidth() / 2, xyPadRect.getHeight() - ball.getWidth() / 2);
 
-    return Point<float> (xPos, yPos);
+    return juce::Point<float> (xPos, yPos);
 }
 
 void CabbageXYPad::setValues (float x, float y, bool notify)

--- a/Source/Widgets/CabbageXYPad.h
+++ b/Source/Widgets/CabbageXYPad.h
@@ -50,8 +50,8 @@ class CabbageXYPad
     float minX, maxX, minY, maxY, valueX, valueY;
     bool rightMouseButtonDown = false;
 
-    Point<float> currentMouseXY;
-    Point<float> mouseDownXY;
+    juce::Point<float> currentMouseXY;
+    juce::Point<float> mouseDownXY;
     
     String xPrefix = "";
     String xPostfix = "";
@@ -60,7 +60,7 @@ class CabbageXYPad
 
     class XYBall : public Component
     {
-        Point<int> ballXY;
+        juce::Point<int> ballXY;
         Colour colour;
 
     public:
@@ -114,10 +114,10 @@ public:
 
     void setValues (float x, float y, bool notify = true);
 
-    Point<int> constrainPosition (float x, float y);
-    Point<float> getPositionAsValue (Point<float> position);
-    Point<float> getValueAsPosition (Point<float> position);
-    void setPositionAsValue (Point<float> position);
+    juce::Point<int> constrainPosition (float x, float y);
+    juce::Point<float> getPositionAsValue (juce::Point<float> position);
+    juce::Point<float> getValueAsPosition (juce::Point<float> position);
+    void setPositionAsValue (juce::Point<float> position);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (CabbageXYPad);
 };
@@ -134,7 +134,7 @@ class XYPadAutomator : public ChangeBroadcaster, public Timer
     Line<float> dragLine;
     bool isPluginEditorOpen = false;
     bool repaintBackground = false;
-    Point<double> position;
+    juce::Point<double> position;
     float xMin, xMax, yMin, yMax, velocity;
     AudioProcessor* owner;
 
@@ -164,7 +164,7 @@ public:
     {
         this->name = name;
     }
-    void setPosition (const Point<double>& position)
+    void setPosition (const juce::Point<double>& position)
     {
         this->position = position;
     }
@@ -212,7 +212,7 @@ public:
     {
         return isPluginEditorOpen;
     }
-    const Point<double>& getPosition() const
+    const juce::Point<double>& getPosition() const
     {
         return position;
     }

--- a/Source/Widgets/Legacy/TableManager.cpp
+++ b/Source/Widgets/Legacy/TableManager.cpp
@@ -1457,7 +1457,7 @@ void HandleViewer::positionHandle (const MouseEvent& e)
             else
             {
                 handles[i]->setTopLeftPosition (getSnapXPosition (e.x), getSnapYPosition (double (e.y)));
-                Point<double> relPos (handles[i]->getPosition().getX(), handles[i]->getPosition().getY());
+                juce::Point<double> relPos (handles[i]->getPosition().getX(), handles[i]->getPosition().getY());
                 handles[i]->setRelativePosition (relPos);
                 handles[i]->sendChangeMessage();
                 handleExists = true;
@@ -1727,7 +1727,7 @@ HandleComponent* HandleComponent::getNextHandle()
     return getParentHandleViewer()->getNextHandle (this);
 }
 //==================================================================================
-void HandleComponent::setRelativePosition (Point<double> pos)
+void HandleComponent::setRelativePosition (juce::Point<double> pos)
 {
     //convert position so that it's scaled between 0 and 1
     xPosRelative = jlimit (0.0, 1.0, pos.getX() / (double)this->getParentHandleViewer()->getWidth());
@@ -1810,7 +1810,7 @@ void HandleComponent::mouseDrag (const MouseEvent& e)
     yPos = jlimit (0.0, getParentComponent()->getHeight() + 0.0, yPos + (getHeight() / 2.f));
 
     setPosition (viewer->getSnapXPosition (xPos), viewer->getSnapYPosition (yPos), (getWidth() == FIXED_WIDTH ? true : false));
-    setRelativePosition (Point<double> (viewer->getSnapXPosition (xPos), viewer->getSnapYPosition (yPos)));
+    setRelativePosition (juce::Point<double> (viewer->getSnapXPosition (xPos), viewer->getSnapYPosition (yPos)));
 
     mouseStatus = "mouseDrag";
     sendChangeMessage();

--- a/Source/Widgets/Legacy/TableManager.h
+++ b/Source/Widgets/Legacy/TableManager.h
@@ -138,7 +138,7 @@ public:
     void mouseWheelMove (const MouseEvent&, const MouseWheelDetails& wheel) override;
     void setWaveform (AudioSampleBuffer buffer);
     void enableEditMode (StringArray pFields);
-    Point<int> tableTopAndHeight;
+    juce::Point<int> tableTopAndHeight;
     void setWaveform (Array<float, CriticalSection> buffer, bool updateRange = true);
     void createImage (String filename);
     void addTable (int sr, const Colour col, int gen, var ampRange);
@@ -371,7 +371,7 @@ public:
     int height, width;
     int x, y;
     void setColour (Colour icolour);
-    void setRelativePosition (Point<double> point);
+    void setRelativePosition (juce::Point<double> point);
 
     HandleViewer* getParentHandleViewer()
     {


### PR DESCRIPTION
When building on MacOS Catalina a `"Reference to 'Point' is ambiguous"` compile error occurs due to the `Point` type being present in both the Juce headers and the system headers. This change fixes the issue by qualifying all uses of the Juce `Point` type with the `juce` namespace.

fixes #92