### PR TITLE
Fix --destination command line parameter handling

### DIFF
--- a/Source/Utilities/CabbageExportPlugin.cpp
+++ b/Source/Utilities/CabbageExportPlugin.cpp
@@ -104,7 +104,11 @@ void PluginExporter::exportPlugin (String type, File csdFile, String pluginId, S
         }
         else if(promptForFilename == false)
         {
-            const String newFile = csdFile.getParentDirectory().getFullPathName()+"/"+csdFile.getFileNameWithoutExtension();
+            String newFile = destination;
+            if (newFile == "")
+            {
+                newFile = csdFile.getParentDirectory().getFullPathName()+"/"+csdFile.getFileNameWithoutExtension();
+            }
             writePluginFileToDisk(newFile, csdFile, VSTData, fileExtension, pluginId, type,
                                   encrypt);
             


### PR DESCRIPTION
The `--destination` command line parameter is being ignored. The plugin output path is always generated from the input .csd file path. This change makes the plugin output path get set to the path set by the `--destination` command line parameter.