### PR TITLE
Don't open command lines with "--export-" when another instance starts

### DIFF
--- a/Source/Cabbage.cpp
+++ b/Source/Cabbage.cpp
@@ -50,7 +50,10 @@ void Cabbage::anotherInstanceStarted (const String& commandLine)
 {
     if (CabbageDocumentWindow* mainApp = dynamic_cast<CabbageDocumentWindow*> (documentWindow.get()))
     {
-        mainApp->openFile(commandLine);
+        if (!commandLine.contains("--export-"))
+        {
+            mainApp->openFile(commandLine);
+        }
     }
 }
 


### PR DESCRIPTION
When an instance of Cabbage is running on MacOS and another instance is started with an --export-* command line parameter, Cabbage assumes the entire command line is a .csd file. When the .csd file is not found Cabbage shows the file open dialog. This change fixes the issue by only opening the command line if "--export-" is not found in it.