### PR TITLE
Fix crashes in Apple's Logic DAW

### DIFF
--- a/Source/Audio/Plugins/CsoundPluginProcessor.cpp
+++ b/Source/Audio/Plugins/CsoundPluginProcessor.cpp
@@ -110,6 +110,7 @@ bool CsoundPluginProcessor::setupAndCompileCsound(File currentCsdFile, File file
     //int test = csound->SetGlobalEnv("OPCODE6DIR64", );
     CabbageUtilities::debug("Env var set");
     //csoundSetOpcodedir("/Library/Frameworks/CsoundLib64.framework/Versions/6.0/Resources/Opcodes64");
+    Logger::writeToLog(String::formatted("Resetting csound ...\ncsound = 0x%x", long(csound.get())));
 	csound.reset (new Csound());
     
 	csdFilePath = filePath;
@@ -235,7 +236,24 @@ void CsoundPluginProcessor::createFileLogger (File csdFile)
 //==============================================================================
 void CsoundPluginProcessor::initAllCsoundChannels (ValueTree cabbageData)
 {
-        
+    Logger::writeToLog("initAllCsoundChannels (ValueTree cabbageData) ...");
+    if (!csound)
+    {
+        Logger::writeToLog("csound not initialized");
+        return;
+    }
+    else
+    {
+        Logger::writeToLog(String::formatted("csound = 0x%x", long(csound.get())));
+        Logger::writeToLog(String::formatted("handle = 0x%x", long(csound->GetCsound())));
+    }
+    
+    if (!csdCompiledWithoutError())
+    {
+        Logger::writeToLog("csound not compiled");
+        return;
+    }
+    
     for (int i = 0; i < cabbageData.getNumChildren(); i++)
     {
         const String typeOfWidget = CabbageWidgetData::getStringProp (cabbageData.getChild (i), CabbageIdentifierIds::type);
@@ -426,6 +444,7 @@ void CsoundPluginProcessor::initAllCsoundChannels (ValueTree cabbageData)
 
     csound->PerformKsmps();
 
+    Logger::writeToLog("initAllCsoundChannels (ValueTree cabbageData) - done");
 
 }
 //==============================================================================


### PR DESCRIPTION
Apple's Logic DAW is doing something under the hood at startup that frequently causes Csound compile to fail. When this happens, Cabbage plugins ignore the failure and crash in `CsoundPluginProcessor::initAllCsoundChannels` when trying to call `csound->PerformKsmps` on an invalid Csound instance. This change prevents the crash by returning early from `CsoundPluginProcessor::initAllCsoundChannels` if Csound failed to compile the .csd.

Note that this does not prevent plugins from loading correctly after Logic is done starting up. Maybe Logic does some initial tests on plugins at startup that causes Csound compile to fail sometimes?