### PR TITLE
Don't create code editor when command line has export parameter

### DIFF
--- a/Source/Application/CabbageDocumentWindow.cpp
+++ b/Source/Application/CabbageDocumentWindow.cpp
@@ -94,7 +94,7 @@ commandLineArgs (commandLineParams)
                     inputFileName = commandLineParams[inputFileNameIndex].trim().removeCharacters ("\"");
                     if (File (inputFileName).existsAsFile())
                     {
-                        content->openFile (inputFileName);
+                        content->openFile (inputFileName, false, true);
                         auto inputFile = File (inputFileName);
                         auto id = getPluginInfo (inputFile, "id");
                         auto promptForFilename = false;

--- a/Source/Application/CabbageMainComponent.cpp
+++ b/Source/Application/CabbageMainComponent.cpp
@@ -1514,7 +1514,7 @@ void CabbageMainComponent::toggleBrowser()
     }
 }
 //==================================================================================
-const File CabbageMainComponent::openFile (String filename, bool updateRecentFiles)
+const File CabbageMainComponent::openFile (String filename, bool updateRecentFiles, bool exportingPlugin)
 {
     stopTimer();
     //stopCsoundForNode (filename);
@@ -1552,7 +1552,10 @@ const File CabbageMainComponent::openFile (String filename, bool updateRecentFil
         cabbageSettings->setProperty ("MostRecentFile", currentCsdFile.getFullPathName());
     }
 
-    createCodeEditorForFile (currentCsdFile);
+    if (!exportingPlugin)
+    {
+        createCodeEditorForFile (currentCsdFile);
+    }
 
     return currentCsdFile;
 

--- a/Source/Application/CabbageMainComponent.h
+++ b/Source/Application/CabbageMainComponent.h
@@ -89,7 +89,7 @@ public:
 	void launchSSHFileBrowser(String mode);
 	void enableEditMode();
     void enableAutoUpdateMode();
-	const File openFile(String filename = "", bool updateRecentFiles = true);
+	const File openFile(String filename = "", bool updateRecentFiles = true, bool exportingPlugin = false);
 	void closeDocument();
 	void showSettingsDialog();
 	void saveDocument(bool saveAs = false, bool recompile = true);


### PR DESCRIPTION
This change makes Cabbage skip creating a code editor when opening files if the command line contains an --export-* parameter, which also stops the exported file from being added to the recent files list.