### PR TITLE
Fix Csound IO buffer corruption when in and out channel counts differ

### DIFF
--- a/Source/Audio/Plugins/CsoundPluginProcessor.cpp
+++ b/Source/Audio/Plugins/CsoundPluginProcessor.cpp
@@ -179,6 +179,12 @@ bool CsoundPluginProcessor::setupAndCompileCsound(File currentCsdFile, File file
         csoundParams->nchnls_i_override = numCsoundInputChannels;
     }
     
+    // Update the matchingNumberOfIOChannels flag so the MacOS auval tool doesn't crash when validating
+    // different I/O channel configurations.
+    if (csoundParams->nchnls_i_override != csoundParams->nchnls_override)
+    {
+        matchingNumberOfIOChannels = false;
+    }
 	
 #ifdef CabbagePro
 	const int requestedSampleRate = CabbageUtilities::getHeaderInfo(Encrypt::decode(csdFile), "sr");


### PR DESCRIPTION
On MacOS, the auval tool tests several different configurations with different numbers of input and output channels. When the channel counts don't match, the `CsoundPluginProcessor::matchingNumberOfIOChannels` flag is not set correctly. This causes Cabbage to read from and write to invalid memory locations when updating the Csound IO buffers. The `CsoundPluginProcessor::isLogic` flag prevents this from happening in the Logic Pro DAW, but the auval tool does not get reported as the Logic DAW so the special handling for mismatched channel counts is not triggered.

This change fixes the issue by updating the `CsoundPluginProcessor::matchingNumberOfIOChannels` flag in the `CsoundPluginProcessor::setupAndCompileCsound` function right after the actual number of input and output channels is determined.