### PR TITLE
Fix crashes in editor when auto-loading from disk

### DIFF
--- a/Source/Audio/Plugins/CabbagePluginProcessor.cpp
+++ b/Source/Audio/Plugins/CabbagePluginProcessor.cpp
@@ -1247,6 +1247,9 @@ void CabbagePluginProcessor::getChannelDataFromCsound()
 }
 
 void CabbagePluginProcessor::triggerCsoundEvents() {
+    if (!getCsound())
+        return;
+    
     for (int x = 0; x < matrixEventSequencers.size(); x++) {
         const ValueTree widgetData = CabbageWidgetData::getValueTreeForComponent(cabbageWidgets,
                                                                                  matrixEventSequencers[x]->channel,
@@ -1339,6 +1342,9 @@ CabbageAudioParameter *CabbagePluginProcessor::getParameterForXYPad(String name)
 
 //==============================================================================
 void CabbagePluginProcessor::setCabbageParameter(String channel, float value) {
+    if (!getCsound())
+        return;
+    
     getCsound()->SetChannel(channel.toUTF8().getAddress(), value);
 }
 


### PR DESCRIPTION
When auto-loading from disk, `CabbagePluginProcessor::triggerCsoundEvents()` and `CabbagePluginProcessor::setCabbageParameter()` crash intermittently due to `getCsound()` sometimes returning a null pointer. This change avoids the crash by returning early if `getCsound()` returns a null pointer.