### PR TITLE
Rack plugins have fixed height but flexible width

### DIFF
--- a/Docs/markdown/exporting_plugins.md
+++ b/Docs/markdown/exporting_plugins.md
@@ -17,38 +17,6 @@ It's important that you keep these files together. Failure to do so will cause p
 >In order to make changes to your newly exported plugin you only need to edit the associated .csd file. You don't need to keep exporting the plugin each time. For instance, on Windows you might have a plugin called "SavageCabbage.dll". If you wish to make some changes to this plugin you only have to edit the corresponding "SavageCabbage.csd" file. In order to see the changes in your plugin host you will need to delete and reinstate the plugin from the track. Once you remove and add the plugin it will show the new changes. 
 
 
-### Exporting your instruments as VCV Rack modules
+## Exporting your instruments as VCV Rack modules
 
-Cabbage also provides experimental support for the creation of VCV Rack modules. The steps are the same to those outlined in the section above, but there are some caveats you should be aware of (see below). 
-
-![Run instrument](images/vcvRackExample.gif) 
-
-The simplest thing to do to get started with VCV Rack module is to create a new VCV Rack file from the 'New' dialogue window. When you export your file Cabbage will bundle all the VCV Rack files together into a single folder. This folder must be placed in the [Rack plugins-v1 folder](https://vcvrack.com/manual/FAQ.html#where-is-the-rack-user-folder). Once it has been created you can start editing the .csd file from there directly to save having to export each time you wish to update your module. 
-
-## The following caveats apply to all Cabbage VCV Rack modules:
-
-* Plugin height MUST be 380. If you make your instrument taller or shorter than this it won't fit in the rack.
-
-* Of the standard set of Cabbage widgets, only rslider, label, groupbox, checkbox, button, combobox and image widgets are supported (with reduced functionality). Only the most basic identifiers are supported, so please keep things simple and keep testing your modules to make sure you are not using unsupported identifiers. Also note that the combobox is more like a multi-switch than a traditional combobox.  
-
-* CabbageRack provides 3 VCV Rack specific widgets, `cvInput` and `cvOutput`, (see below) and `light`. The `light` widget can be triggered from a Csound instrument to give users visual feedback their modules.
-
-* Unlike the other audio plugin interfaces for Cabbage, CabbageRack does not use the `in` and `out` family of opcodes. It uses audio-rate channels instead. Each `cvInput` and `cvOutput` widget is linked to a set of a-rate `chnget` and `chnset` opcodes. The reason for this is allow maximum configurability of inputs and outputs.
-
-* Slider skew values are not yet supported. 
-
-* The slider increment identifier can be set to a number equal or greater than one to allow snapping to integer values, but it will only snap to multiple of 1.
-
-* Modules are named by their folder, which should contain a .csd file of the same nam. No whitespaces can be used. Use _ or - instead.
-
-* Colours are RGBA only, there is no support for CSS colour names.
-
-* This interface uses a much simpler parser than the one used in Cabbage plugins, spaces between identifiers and opening brackets will cause issues. 
-
-* This interface draws all GUI widgets using an entirely different library than the native Cabbage app, so expect some things to look slightly different between this interface and an exported Cabbage audio plugins. 
-
-* Only the light widget can be updated from Csound.
-
-* VCV Rack auto-saves sessions. If you make some changes to your Cabbage module and reload, VCV Rack may try to load settings for controls that no longer exist. This might cause VCV Rack to crash. If so, you will need to edit or delete the auto-saved file.
-
-
+Cabbage also provides experimental support for the creation of VCV Rack modules. The steps are the same to those outlined in the section above, but there are some caveats you should be aware of. See the [exporting Rack modules](./exporting_rack_modules.md) document for further details.

--- a/Docs/markdown/exporting_plugins.md
+++ b/Docs/markdown/exporting_plugins.md
@@ -27,7 +27,7 @@ The simplest thing to do to get started with VCV Rack module is to create a new 
 
 ## The following caveats apply to all Cabbage VCV Rack modules:
 
-* Plugin width MUST be 380. If you make your instrument bigger or smaller than this it won't fit in the rack.
+* Plugin height MUST be 380. If you make your instrument taller or shorter than this it won't fit in the rack.
 
 * Of the standard set of Cabbage widgets, only rslider, label, groupbox, checkbox, button, combobox and image widgets are supported (with reduced functionality). Only the most basic identifiers are supported, so please keep things simple and keep testing your modules to make sure you are not using unsupported identifiers. Also note that the combobox is more like a multi-switch than a traditional combobox.  
 

--- a/Docs/markdown/exporting_rack_modules.md
+++ b/Docs/markdown/exporting_rack_modules.md
@@ -6,7 +6,7 @@ Cabbage provides experimental support for the creation of VCV Rack modules. The 
 
 The simplest thing to get started with a VCV Rack module is to create a new VCV Rack file from the 'New' dialogue window. Cabbage will bundle all the VCV Rack files into a single folder when you export your file. You must place this folder in the [Rack plugins-v1 folder](https://vcvrack.com/manual/FAQ.html#where-is-the-rack-user-folder). From there, you can start editing the .csd file directly to save having to export each time you wish to update your module. 
 
-## The following caveats apply to all Cabbage VCV Rack modules:
+## Caveats that apply to Cabbage VCV Rack modules
 
 * Plugin height MUST be 380. If you make your instrument taller or shorter than this, it won't fit in the rack.
 

--- a/Docs/markdown/exporting_rack_modules.md
+++ b/Docs/markdown/exporting_rack_modules.md
@@ -1,29 +1,28 @@
 # Exporting your instruments as VCV Rack modules
 
-
-Cabbage also experimental support for the creation of VCV Rack modules. The steps are the same to those outlined in the previous section,but there are some caveats you should be aware of (see below). 
+Cabbage provides experimental support for the creation of VCV Rack modules. The steps are the same as those outlined in the previous section, but there are some caveats you should be aware of (see below). 
 
 ![Run instrument](images/vcvRackExample.gif) 
 
-The simplest thing to do to get started with VCV Rack module is to create a new VCV Rack file from the 'New' dialogue window. When you export your file Cabbage will bundle all the VCV Rack files together into a single folder. This folder must be placed in the [Rack plugins-v1 folder](https://vcvrack.com/manual/FAQ.html#where-is-the-rack-user-folder). Once it has been created you can start editing the .csd file from there directly to save having to export each time you wish to update your module. 
+The simplest thing to get started with a VCV Rack module is to create a new VCV Rack file from the 'New' dialogue window. Cabbage will bundle all the VCV Rack files into a single folder when you export your file. You must place this folder in the [Rack plugins-v1 folder](https://vcvrack.com/manual/FAQ.html#where-is-the-rack-user-folder). From there, you can start editing the .csd file directly to save having to export each time you wish to update your module. 
 
 ## The following caveats apply to all Cabbage VCV Rack modules:
 
-* Plugin height MUST be 380. If you make your instrument taller or shorter than this it won't fit in the rack.
+* Plugin height MUST be 380. If you make your instrument taller or shorter than this, it won't fit in the rack.
 
-* Of the standard set of Cabbage widgets, only rslider, label, groupbox, checkbox, button, combobox and image widgets are supported (with reduced functionality). Only the most basic identifiers are supported, so please keep things simple and keep testing your modules to make sure you are not using unsupported identifiers. Also note that the combobox is more like a multi-switch than a traditional combobox.  
+* Of the standard set of Cabbage widgets, only `rslider`, `label`, `groupbox`, `checkbox`, `button`, `combobox`, and `image` widgets are supported (with reduced functionality). Only the most basic identifiers are supported, so please keep things simple and keep testing your modules to make sure you are not using unsupported identifiers. Also, note that the `combobox` is more like a multi-switch than a traditional `combobox`.  
 
-* CabbageRack provides 3 VCV Rack specific widgets, `cvInput` and `cvOutput`, (see below) and `light`. The `light` widget can be triggered from a Csound instrument to give users visual feedback their modules.
+* CabbageRack provides 3 VCV Rack specific widgets, `cvInput` and `cvOutput`, (see below) and `light`. A Csound instrument can trigger the `light` widget to give users visual feedback on their modules.
 
-* Unlike the other audio plugin interfaces for Cabbage, CabbageRack does not use the `in` and `out` family of opcodes. It uses audio-rate channels instead. Each `cvInput` and `cvOutput` widget is linked to a set of a-rate `chnget` and `chnset` opcodes. The reason for this is allow maximum configurability of inputs and outputs.
+* Unlike the other audio plugin interfaces for Cabbage, CabbageRack does not use the `in` and `out` family of opcodes. It uses audio-rate channels instead. Each `cvInput` and `cvOutput` widget is linked to a set of a-rate `chnget` and `chnset` opcodes. The reason for this is to allow maximum configurability of inputs and outputs.
 
 * Slider skew values are not yet supported. 
 
-* The slider increment identifier can be set to a number equal or greater than one to allow snapping to integer values, but it will only snap to multiple of 1.
+* The slider increment identifier can be set to a number equal or greater than one to allow snapping to integer values, but it will only snap to multiples of 1.
 
-* Modules are named by their folder, which should contain a .csd file of the same nam. No whitespaces can be used. Use _ or - instead.
+* Modules names come from their folder, which should contain a .csd file of the same name. Module names can contain no whitespaces. Use _ or - instead.
 
-* Colours are RGBA only, there is no support for CSS colour names.
+* Colours are RGBA only, and there is no support for CSS colour names.
 
 * This interface uses a much simpler parser than the one used in Cabbage plugins, spaces between identifiers and opening brackets will cause issues. 
 
@@ -31,4 +30,4 @@ The simplest thing to do to get started with VCV Rack module is to create a new 
 
 * Only the light widget can be updated from Csound.
 
-* VCV Rack auto-saves sessions. If you make some changes to your Cabbage module and reload, VCV Rack may try to load settings for controls that no longer exist. This might cause VCV Rack to crash. If so, you will need to edit or delete the auto-saved file.
+* VCV Rack auto-saves sessions. If you make some changes to your Cabbage module and reload, VCV Rack may try to load settings for controls that no longer exist. The missing settings might cause VCV Rack to crash. If so, you will need to edit or delete the auto-saved file.

--- a/Docs/markdown/exporting_rack_modules.md
+++ b/Docs/markdown/exporting_rack_modules.md
@@ -9,7 +9,7 @@ The simplest thing to do to get started with VCV Rack module is to create a new 
 
 ## The following caveats apply to all Cabbage VCV Rack modules:
 
-* Plugin width MUST be 380. If you make your instrument bigger or smaller than this it won't fit in the rack.
+* Plugin height MUST be 380. If you make your instrument taller or shorter than this it won't fit in the rack.
 
 * Of the standard set of Cabbage widgets, only rslider, label, groupbox, checkbox, button, combobox and image widgets are supported (with reduced functionality). Only the most basic identifiers are supported, so please keep things simple and keep testing your modules to make sure you are not using unsupported identifiers. Also note that the combobox is more like a multi-switch than a traditional combobox.  
 


### PR DESCRIPTION
Perhaps I'm misunderstanding the order of Cabbage width/height arguments. However, Rack modules have a fixed height (from the user perspective) and flexible width. 

```csound
<Cabbage>
form caption("CabbageModule") size(100, 380), colour(255, 255, 255), pluginid("def1")
...
</Cabbage>
```

![image](https://user-images.githubusercontent.com/17307/134866099-2328e53c-bf60-4f0b-8413-2b6405692315.png)

I'm updating the docs here as this might be a relatively small misconception to fix :-)

I also double-checked to make sure I didn't lose any details when removing the duplicate documentation and adding a link. Finally, I cleaned up the article a bit with a grammar checker.