### PR TITLE
Fixes for comboboxes

### DIFF
--- a/Source/Audio/Plugins/CabbagePluginProcessor.cpp
+++ b/Source/Audio/Plugins/CabbagePluginProcessor.cpp
@@ -886,7 +886,7 @@ void CabbagePluginProcessor::createCabbageParameters()
 					if (CabbageWidgetData::getStringProp(cabbageWidgets.getChild(i), CabbageIdentifierIds::channeltype) == "string")
 					{
 						const String workingDir = CabbageWidgetData::getStringProp(cabbageWidgets.getChild(i), CabbageIdentifierIds::currentdir);
-						const String fileType = CabbageWidgetData::getStringProp(cabbageWidgets.getChild(i), "filetype");
+						const String fileType = CabbageWidgetData::getStringProp(cabbageWidgets.getChild(i), CabbageIdentifierIds::filetype);
 						int numOfFiles;
 						Array<File> folderFiles;
 						StringArray comboItems;
@@ -1230,8 +1230,8 @@ void CabbagePluginProcessor::restorePluginPreset(String presetName, String fileN
                 }
                 else
                 {
-                    if (CabbageWidgetData::getStringProp(valueTree, "filetype") != "preset"
-                        && CabbageWidgetData::getStringProp(valueTree, "filetype") != "*.snaps" &&
+                    if (CabbageWidgetData::getStringProp(valueTree, CabbageIdentifierIds::filetype) != "preset"
+                        && CabbageWidgetData::getStringProp(valueTree, CabbageIdentifierIds::filetype) != "*.snaps" &&
                         CabbageWidgetData::getStringProp(valueTree, CabbageIdentifierIds::channeltype) != "string")
                         CabbageWidgetData::setNumProp(valueTree, CabbageIdentifierIds::value,
                                                       presetData.value().get<float>());

--- a/Source/Audio/Plugins/CsoundPluginProcessor.cpp
+++ b/Source/Audio/Plugins/CsoundPluginProcessor.cpp
@@ -480,7 +480,7 @@ void CsoundPluginProcessor::initAllCsoundChannels (ValueTree cabbageData)
             {
                 if (typeOfWidget == CabbageWidgetTypes::combobox || typeOfWidget == CabbageWidgetTypes::listbox)
                 {
-                    const String fileType = CabbageWidgetData::getStringProp(cabbageData.getChild(i), "filetype");
+                    const String fileType = CabbageWidgetData::getStringProp(cabbageData.getChild(i), CabbageIdentifierIds::filetype);
                     //if we are dealing with a combobox that reads files from a directory, we need to load them before the GUI opens...
                     if (!CabbageWidgetData::getStringProp(cabbageData.getChild(i), CabbageIdentifierIds::filetype).contains("preset")
                         && !CabbageWidgetData::getStringProp(cabbageData.getChild(i), CabbageIdentifierIds::filetype).contains("*.snaps")
@@ -497,8 +497,7 @@ void CsoundPluginProcessor::initAllCsoundChannels (ValueTree cabbageData)
                             CabbageUtilities::searchDirectoryForFiles(workingDir, fileType, folderFiles, comboItems, numOfFiles);
                             const String currentValue = CabbageWidgetData::getStringProp(cabbageData.getChild(i), CabbageIdentifierIds::value);
 
-                            const int index = comboItems.indexOf(currentValue) + 1;
-                            const String test = folderFiles[index].getFullPathName();
+                            const int index = comboItems.indexOf(currentValue);
                             const String channel = CabbageWidgetData::getStringProp(cabbageData.getChild(i), CabbageIdentifierIds::channel);
 
                             csound->SetStringChannel(CabbageWidgetData::getStringProp(cabbageData.getChild(i), CabbageIdentifierIds::channel).getCharPointer(),


### PR DESCRIPTION
The string literal "filetype" is used some places where "fileType" should be used instead. This causes comboboxes to not have their channel data populated properly sometimes.

I fixed these, and also an off-by-one error