### PR TITLE
Make combo box channel contents consistent

### DIFF
--- a/Source/Widgets/CabbageComboBox.cpp
+++ b/Source/Widgets/CabbageComboBox.cpp
@@ -398,7 +398,7 @@ void CabbageComboBox::comboBoxChanged (ComboBox* combo) //this listener is only 
 		if (fileType.isNotEmpty())
 		{
 			String test = folderFiles[index].getFullPathName();
-			owner->sendChannelStringDataToCsound(getChannel(), folderFiles[index].getFullPathName().replaceCharacters("\\", "/"));
+			owner->sendChannelStringDataToCsound(getChannel(), folderFiles[index].getFileNameWithoutExtension());
             CabbageWidgetData::setProperty (widgetData, CabbageIdentifierIds::value, folderFiles[index].getFileName());
 		}
         else


### PR DESCRIPTION
Before my changes, one line in the combo box impl was sending just the filename to csound, and the CSoundPluginProcessor was sending the full path. My changes made the CSoundPluginProcessor also send just the filename, but I missed one line which I had uncommented and was still sending the full path.