### PR TITLE
Guard cabbage widget data read with scoped lock

### DIFF
--- a/Source/Audio/Plugins/CabbagePluginProcessor.cpp
+++ b/Source/Audio/Plugins/CabbagePluginProcessor.cpp
@@ -1495,6 +1495,8 @@ void CabbagePluginProcessor::getIdentifierDataFromCsound()
     
     identData = *pd;
     
+    CriticalSection::ScopedLockType scopedLock(identData->data.getLock());
+
     for(auto && i : identData->data)
     {
         if(i.identifier.getCharPointer().getAddress() != nullptr)
@@ -1916,12 +1918,3 @@ void CabbagePluginProcessor::prepareToPlay(double sampleRate, int samplesPerBloc
 	
 
 }
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
`CabbagePluginProcessor::getIdentifierDataFromCsound()` is not locking the data array before reading and clearing it. This causes hanging and crashes, especially when rendering in Reaper with 20+ Cabbage plugins running.

This change fixes the issue by adding the missing lock in `CabbagePluginProcessor::getIdentifierDataFromCsound()`.