### PR TITLE
Improve identifier performance

### DIFF
--- a/Source/Audio/Plugins/CabbagePluginProcessor.cpp
+++ b/Source/Audio/Plugins/CabbagePluginProcessor.cpp
@@ -1495,6 +1495,8 @@ void CabbagePluginProcessor::getIdentifierDataFromCsound()
     
     identData = *pd;
     
+    CriticalSection::ScopedLockType scopedLock(identData->data.getLock());
+
     for(auto && i : identData->data)
     {
         if(i.identifier.getCharPointer().getAddress() != nullptr)
@@ -1916,12 +1918,3 @@ void CabbagePluginProcessor::prepareToPlay(double sampleRate, int samplesPerBloc
 	
 
 }
-
-
-
-
-
-
-
-
-

--- a/Source/Audio/Plugins/CabbagePluginProcessor.cpp
+++ b/Source/Audio/Plugins/CabbagePluginProcessor.cpp
@@ -1507,7 +1507,7 @@ void CabbagePluginProcessor::getIdentifierDataFromCsound()
 			auto child = cabbageWidgets.getChildWithName(name);
             if(child.isValid())
             {
-                const String widgetType(CabbageWidgetData::getStringProp(child, "type"));
+                const String widgetType(CabbageWidgetData::getStringProp(child, CabbageIdentifierIds::type));
 
                 if(!i.args.isUndefined())
                 {

--- a/Source/Audio/Plugins/CabbagePluginProcessor.cpp
+++ b/Source/Audio/Plugins/CabbagePluginProcessor.cpp
@@ -1501,12 +1501,12 @@ void CabbagePluginProcessor::getIdentifierDataFromCsound()
     {
         if(i.identifier.getCharPointer().getAddress() != nullptr)
         {
-            const auto identifier = i.identifier;
-            const auto name = i.name;
+            const auto& identifier = i.identifier;
+            const auto& name = i.name;
 
-            if(cabbageWidgets.getChildWithName(name).isValid())
+			auto child = cabbageWidgets.getChildWithName(name);
+            if(child.isValid())
             {
-                const auto child = cabbageWidgets.getChildWithName(name);
                 const String widgetType(CabbageWidgetData::getStringProp(child, "type"));
 
                 if(!i.args.isUndefined())
@@ -1521,46 +1521,46 @@ void CabbagePluginProcessor::getIdentifierDataFromCsound()
                                 colourTokens += String(int(i.args[x])) + ",";
                             }
                             if(identifier.toString().contains(":"))
-                                CabbageWidgetData::setColourByNumber(colourTokens.dropLastCharacters(1), cabbageWidgets.getChildWithName(name), identifier.toString());
+                                CabbageWidgetData::setColourByNumber(colourTokens.dropLastCharacters(1), child, identifier.toString());
                             else
-                                cabbageWidgets.getChildWithName(name).setProperty(identifier, CabbageWidgetData::getColourFromText(colourTokens.dropLastCharacters(1)).toString(), nullptr);
+                                child.setProperty(identifier, CabbageWidgetData::getColourFromText(colourTokens.dropLastCharacters(1)).toString(), nullptr);
                         }
                         else if(identifier == CabbageIdentifierIds::populate)
                         {
-                            cabbageWidgets.getChildWithName(name).setProperty(CabbageIdentifierIds::refreshfiles,Random::getSystemRandom().nextInt(), nullptr);
+                            child.setProperty(CabbageIdentifierIds::refreshfiles,Random::getSystemRandom().nextInt(), nullptr);
                         }
                         else if(identifier == CabbageIdentifierIds::bounds)
                         {
-                            CabbageWidgetData::setBounds(cabbageWidgets.getChildWithName(name), juce::Rectangle<int>( i.args[0],
+                            CabbageWidgetData::setBounds(child, juce::Rectangle<int>( i.args[0],
                                                                                                                i.args[1],
                                                                                                                i.args[2],
                                                                                                                i.args[3]));
                         }
                         else if (identifier == CabbageIdentifierIds::rotate)
                         {
-                            cabbageWidgets.getChildWithName(name).setProperty(CabbageIdentifierIds::rotate, i.args[0], nullptr);
-                            cabbageWidgets.getChildWithName(name).setProperty(CabbageIdentifierIds::pivotx, i.args[1], nullptr);
-                            cabbageWidgets.getChildWithName(name).setProperty(CabbageIdentifierIds::pivoty, i.args[2], nullptr);
+                            child.setProperty(CabbageIdentifierIds::rotate, i.args[0], nullptr);
+                            child.setProperty(CabbageIdentifierIds::pivotx, i.args[1], nullptr);
+                            child.setProperty(CabbageIdentifierIds::pivoty, i.args[2], nullptr);
                         }
                         /*else if (widgetType == CabbageWidgetTypes::hrange || widgetType == CabbageWidgetTypes::hrange &&
                             identifier == CabbageIdentifierIds::value)
                         {
-                            var channels = cabbageWidgets.getChildWithName(name).getProperty(CabbageIdentifierIds::channel);
+                            var channels = child.getProperty(CabbageIdentifierIds::channel);
                             const float min = getCsound()->GetChannel(channels[0].toString().toUTF8());
                             const float max = getCsound()->GetChannel(channels[1].toString().toUTF8());
-                            cabbageWidgets.getChildWithName(name).setProperty(CabbageIdentifierIds::minvalue, min, nullptr);
-                            cabbageWidgets.getChildWithName(name).setProperty(CabbageIdentifierIds::maxvalue, max, nullptr);
+                            child.setProperty(CabbageIdentifierIds::minvalue, min, nullptr);
+                            child.setProperty(CabbageIdentifierIds::maxvalue, max, nullptr);
 
                         }*/
                         else
                         {
-                            cabbageWidgets.getChildWithName(name).setProperty(identifier,i.args, nullptr);
+                            child.setProperty(identifier,i.args, nullptr);
                         }
 
 
                         if(identifier == CabbageIdentifierIds::value && getChnsetGestureMode() == 1)
                         {
-                            var channels = cabbageWidgets.getChildWithName(name).getProperty(CabbageIdentifierIds::channel);
+                            var channels = child.getProperty(CabbageIdentifierIds::channel);
                             for (auto cabbageParam : getCabbageParameters())
                             {
                                 if (cabbageParam->getChannel() == channels[0].toString())
@@ -1583,22 +1583,22 @@ void CabbagePluginProcessor::getIdentifierDataFromCsound()
                     else
                     {                       
                         const auto argString = i.args.toString();
-                        CabbageWidgetData::setCustomWidgetState(cabbageWidgets.getChildWithName(name), argString.paddedLeft(' ',1));
+                        CabbageWidgetData::setCustomWidgetState(child, argString.paddedLeft(' ',1));
                         if(argString.contains(CabbageIdentifierIds::populate))
                         {
-                            CabbageWidgetData::setProperty(cabbageWidgets.getChildWithName(name), CabbageIdentifierIds::update, Random::getSystemRandom().nextInt());
+                            CabbageWidgetData::setProperty(child, CabbageIdentifierIds::update, Random::getSystemRandom().nextInt());
                         }
                         /* the following lets up trigger an update even if moveBehind, or toFront have not changed */
                         else if(argString.contains(CabbageIdentifierIds::tofront))
                         {
-                            CabbageWidgetData::setProperty(cabbageWidgets.getChildWithName(name), CabbageIdentifierIds::tofront, Random::getSystemRandom().nextInt());
+                            CabbageWidgetData::setProperty(child, CabbageIdentifierIds::tofront, Random::getSystemRandom().nextInt());
                         }
                         else if(argString.contains(CabbageIdentifierIds::movebehind))
                         {
-                            const String moveBehind = CabbageWidgetData::getProperty(cabbageWidgets.getChildWithName(name), CabbageIdentifierIds::movebehind);
-                            const String chn = CabbageWidgetData::getProperty(cabbageWidgets.getChildWithName(name), CabbageIdentifierIds::channel)[0];
-                            CabbageWidgetData::setProperty(cabbageWidgets.getChildWithName(name), CabbageIdentifierIds::movebehind, "");
-                            CabbageWidgetData::setProperty(cabbageWidgets.getChildWithName(name), CabbageIdentifierIds::update, moveBehind);
+                            const String moveBehind = CabbageWidgetData::getProperty(child, CabbageIdentifierIds::movebehind);
+                            const String chn = CabbageWidgetData::getProperty(child, CabbageIdentifierIds::channel)[0];
+                            CabbageWidgetData::setProperty(child, CabbageIdentifierIds::movebehind, "");
+                            CabbageWidgetData::setProperty(child, CabbageIdentifierIds::update, moveBehind);
                         }
 
 

--- a/Source/Opcodes/CabbageIdentifierOpcodes.cpp
+++ b/Source/Opcodes/CabbageIdentifierOpcodes.cpp
@@ -973,10 +973,7 @@ int SetCabbageValueIdentifier::setAttribute(bool init)
     
     vt = (CabbageWidgetIdentifiers**)csound->query_global_variable("cabbageWidgetData");
     CabbageWidgetIdentifiers* varData = CabbageOpcodes::getGlobalvariable(csound, vt);
-    //this is k-rate only so set init back to true in order to get the correct channel name on each k-cycle
-    CabbageWidgetIdentifiers::IdentifierData data = getValueIdentData(args, true, 0, 1);
 
-    
     int trigger = int(args[2]);
 
     if(trigger == 0 || args.str_data(0).size == 0)
@@ -991,7 +988,9 @@ int SetCabbageValueIdentifier::setAttribute(bool init)
         {
             *value = args[1];
         }
-        
+
+        //this is k-rate only so set init back to true in order to get the correct channel name on each k-cycle
+        CabbageWidgetIdentifiers::IdentifierData data = getValueIdentData(args, true, 0, 1);
         data.args = args[1];
         varData->data.add(data);
 
@@ -1013,7 +1012,6 @@ int SetCabbageValueIdentifierITime::setAttribute(bool init)
     vt = (CabbageWidgetIdentifiers**)csound->query_global_variable("cabbageWidgetData");
     CabbageWidgetIdentifiers* varData = CabbageOpcodes::getGlobalvariable(csound, vt);
     //this is k-rate only so set init back to true in order to get the correct channel name on each k-cycle
-    CabbageWidgetIdentifiers::IdentifierData data = getValueIdentData(args, true, 0, 1);
     if(args.str_data(0).size == 0)
         return OK;
     
@@ -1026,6 +1024,7 @@ int SetCabbageValueIdentifierITime::setAttribute(bool init)
         *value = args[1];
     }
     
+    CabbageWidgetIdentifiers::IdentifierData data = getValueIdentData(args, true, 0, 1);
     data.args = args[1];
     varData->data.add(data);
       
@@ -1048,7 +1047,6 @@ int SetCabbageValueIdentifierSArgs::setAttribute(bool init)
     vt = (CabbageWidgetIdentifiers**)csound->query_global_variable("cabbageWidgetData");
     CabbageWidgetIdentifiers* varData = CabbageOpcodes::getGlobalvariable(csound, vt);
     //this is k-rate only so set init back to true in order to get the correct channel name on each k-cycle
-    CabbageWidgetIdentifiers::IdentifierData data = getValueIdentData(args, true, 0, 1);
     
     int trigger = int(args[2]);
     
@@ -1072,6 +1070,7 @@ int SetCabbageValueIdentifierSArgs::setAttribute(bool init)
             stringdat->size = strlen(args.str_data(1).data) + 1;
         }
         
+        CabbageWidgetIdentifiers::IdentifierData data = getValueIdentData(args, true, 0, 1);
         data.args = args.str_data(1).data;
         varData->data.add(data);
         
@@ -1091,7 +1090,6 @@ int SetCabbageValueIdentifierSArgsITime::setAttribute(bool init)
     vt = (CabbageWidgetIdentifiers**)csound->query_global_variable("cabbageWidgetData");
     CabbageWidgetIdentifiers* varData = CabbageOpcodes::getGlobalvariable(csound, vt);
     //this is k-rate only so set init back to true in order to get the correct channel name on each k-cycle
-    CabbageWidgetIdentifiers::IdentifierData data = getValueIdentData(args, true, 0, 1);
     
     
     if(args.str_data(0).size == 0)
@@ -1099,6 +1097,8 @@ int SetCabbageValueIdentifierSArgsITime::setAttribute(bool init)
     
     varData->data.getLock().enter();
     //varData->canRead.store(false);
+    
+    CabbageWidgetIdentifiers::IdentifierData data = getValueIdentData(args, true, 0, 1);
     data.args = args.str_data(1).data;
     varData->data.add(data);
     

--- a/Source/Opcodes/CabbageIdentifierOpcodes.cpp
+++ b/Source/Opcodes/CabbageIdentifierOpcodes.cpp
@@ -15,6 +15,17 @@
 #include "filesystem.hpp"
 
 
+static std::unordered_map<std::string, Identifier> identifierMap;
+
+
+Identifier CabbageWidgetIdentifiers::getIdentifier(std::string name)
+{
+    if (identifierMap.find(name) == identifierMap.end())
+        identifierMap[name] = Identifier(name);
+    return identifierMap[name];
+}
+
+
 //====================================================================================================
 int CreateCabbageWidget::createWidget()
 {

--- a/Source/Opcodes/CabbageIdentifierOpcodes.h
+++ b/Source/Opcodes/CabbageIdentifierOpcodes.h
@@ -30,6 +30,8 @@ public:
 class CabbageWidgetIdentifiers
 {
 public:
+    static Identifier getIdentifier(std::string name);
+
     struct IdentifierData
     {
         Identifier identifier, name;
@@ -86,7 +88,7 @@ struct CabbageOpcodes
             {
                 name = args.str_data(nameIndex).data;
                 if (name != nullptr && name[0] != 0)
-                    identData.name = name;
+                    identData.name = CabbageWidgetIdentifiers::getIdentifier(name);
             }
         }
 
@@ -114,9 +116,9 @@ struct CabbageOpcodes
         }
         
         if(String(name).isNotEmpty())
-            identData.name = name;
+            identData.name = CabbageWidgetIdentifiers::getIdentifier(name);
         if(String(identifier).isNotEmpty())
-            identData.identifier = Identifier(identifier);
+            identData.identifier = CabbageWidgetIdentifiers::getIdentifier(identifier);
         
         identData.isValid = true;
         return identData;
@@ -128,7 +130,7 @@ struct CabbageOpcodes
         {
             CabbageWidgetIdentifiers::IdentifierData updateData;
             updateData.identifier = CabbageIdentifierIds::update;
-            updateData.name = name;
+            updateData.name = CabbageWidgetIdentifiers::getIdentifier(name);
             updateData.args = value;
             varData->data.add(updateData);
         }

--- a/Source/Opcodes/CabbageIdentifierOpcodes.h
+++ b/Source/Opcodes/CabbageIdentifierOpcodes.h
@@ -76,16 +76,20 @@ struct CabbageOpcodes
     CabbageWidgetIdentifiers::IdentifierData getValueIdentData(csnd::Param<N>& args, bool init, int nameIndex, int identIndex)
     {
         CabbageWidgetIdentifiers::IdentifierData identData;
+        identData.identifier = CabbageIdentifierIds::value;
+
         if(init)
         {
             if(args.str_data(nameIndex).size == 0)
                 name = {};
             else
+            {
                 name = args.str_data(nameIndex).data;
+                if (name != nullptr && name[0] != 0)
+                    identData.name = name;
+            }
         }
 
-        identData.identifier = CabbageIdentifierIds::value;
-        identData.name = name;
         identData.isValid = true;
         return identData;
     }
@@ -500,5 +504,3 @@ struct CabbageCopyFile : csnd::InPlug<64>
     int deinit(){ return OK;  }
     int copyFiles();
 };
-
-

--- a/Source/Widgets/CabbageWidgetData.cpp
+++ b/Source/Widgets/CabbageWidgetData.cpp
@@ -1347,7 +1347,7 @@ void CabbageWidgetData::setRange (StringArray strTokens, ValueTree widgetData, S
 
 //=========================================================================
 // retrieve/set widget tree data
-float CabbageWidgetData::getNumProp (ValueTree widgetData, Identifier prop)
+float CabbageWidgetData::getNumProp (ValueTree widgetData, const Identifier& prop)
 {
     var props = getProperty (widgetData, prop);
 
@@ -1358,7 +1358,7 @@ float CabbageWidgetData::getNumProp (ValueTree widgetData, Identifier prop)
 }
 
 
-String CabbageWidgetData::getStringProp (ValueTree widgetData, Identifier prop)
+String CabbageWidgetData::getStringProp (ValueTree widgetData, const Identifier& prop)
 {
     var strings = getProperty (widgetData, prop);
 
@@ -1371,17 +1371,17 @@ String CabbageWidgetData::getStringProp (ValueTree widgetData, Identifier prop)
 
 }
 
-void CabbageWidgetData::setNumProp (ValueTree widgetData, Identifier prop, float val)
+void CabbageWidgetData::setNumProp (ValueTree widgetData, const Identifier& prop, float val)
 {
     setProperty (widgetData, prop, val);
 }
 
-void CabbageWidgetData::setStringProp (ValueTree widgetData, Identifier name, const String value)
+void CabbageWidgetData::setStringProp (ValueTree widgetData, const Identifier& name, const String value)
 {
     widgetData.setProperty (name, value, 0);
 }
 
-void CabbageWidgetData::setProperty (ValueTree widgetData, Identifier name, const var& value, ValueTree::Listener *listenerToExclude)
+void CabbageWidgetData::setProperty (ValueTree widgetData, const Identifier& name, const var& value, ValueTree::Listener *listenerToExclude)
 {
     Array<var>* array = value.getArray();
 
@@ -1405,7 +1405,7 @@ void CabbageWidgetData::setProperty (ValueTree widgetData, Identifier name, cons
         widgetData.setProperty (name, value, 0);
 }
 
-var CabbageWidgetData::getProperty (ValueTree widgetData, Identifier name)
+var CabbageWidgetData::getProperty (ValueTree widgetData, const Identifier& name)
 {
     return widgetData.getProperty (name);
 }

--- a/Source/Widgets/CabbageWidgetData.h
+++ b/Source/Widgets/CabbageWidgetData.h
@@ -86,14 +86,14 @@ public:
     static void setEventSequencerProperties (ValueTree widgetData, int ID);
     static void setPathProperties (ValueTree widgetData, int ID);
     //============================================================================
-    static float getNumProp (ValueTree widgetData, Identifier prop);
-    static void setNumProp (ValueTree widgetData, Identifier prop, float val);
-    static void setStringProp (ValueTree widgetData, Identifier prop, const String val);
-    static String getStringProp (ValueTree widgetData, Identifier prop);
+    static float getNumProp (ValueTree widgetData, const Identifier& prop);
+    static void setNumProp (ValueTree widgetData, const Identifier& prop, float val);
+    static void setStringProp (ValueTree widgetData, const Identifier& prop, const String val);
+    static String getStringProp (ValueTree widgetData, const Identifier& prop);
     static juce::Rectangle<int> getBounds (ValueTree widgetData);
     static void setBounds (ValueTree widgetData,juce::Rectangle<int> rect);
-    static void setProperty (ValueTree widgetData, Identifier name, const var& value, ValueTree::Listener *listenerToExclude = nullptr);
-    static var getProperty (ValueTree widgetData, Identifier name);
+    static void setProperty (ValueTree widgetData, const Identifier& name, const var& value, ValueTree::Listener *listenerToExclude = nullptr);
+    static var getProperty (ValueTree widgetData, const Identifier& name);
     //============================================================================
     static IdentifiersAndParameters getSetofIdentifiersAndParameters (String lineOfText);
     static var getVarArrayFromTokens (StringArray strTokens);


### PR DESCRIPTION
This change improves performance for identifiers by avoiding repeated calls to the JUCE `Identifier(const char*)` constructor.

This change has other minor performance improvements, too, and contains the same thread lock fix as PR https://github.com/rorywalsh/cabbage/pull/149.